### PR TITLE
Adiciona o type checker e seus testes para o statement de Switch-Case. (Grupo 7)

### DIFF
--- a/src/main/scala/br/unb/cic/oberon/tc/TypeChecker.scala
+++ b/src/main/scala/br/unb/cic/oberon/tc/TypeChecker.scala
@@ -120,7 +120,7 @@ class TypeChecker extends OberonVisitorAdapter {
               }
               else {
                 val list1 = List((stmt, s"Min $min or max $max does not have an integer type"))
-                list2 ++ list1
+                list2 = list1 ++ list2
               } 
           }
 

--- a/src/main/scala/br/unb/cic/oberon/tc/TypeChecker.scala
+++ b/src/main/scala/br/unb/cic/oberon/tc/TypeChecker.scala
@@ -1,6 +1,6 @@
 package br.unb.cic.oberon.tc
 
-import br.unb.cic.oberon.ast.{AddExpression, AndExpression, AssignmentStmt, BoolValue, BooleanType, Brackets, Constant, DivExpression, EQExpression, Expression, FormalArg, GTEExpression, GTExpression, IfElseStmt, IntValue, IntegerType, LTEExpression, LTExpression, MultExpression, NEQExpression, OberonModule, OrExpression, Procedure, ProcedureCallStmt, ReadIntStmt, ReturnStmt, SequenceStmt, Statement, SubExpression, Type, Undef, UndefinedType, VarExpression, VariableDeclaration, WhileStmt, WriteStmt}
+import br.unb.cic.oberon.ast.{AddExpression, AndExpression, AssignmentStmt, BoolValue, BooleanType, Brackets, CaseAlternative, CaseStmt, Constant, DivExpression, EQExpression, Expression, FormalArg, GTEExpression, GTExpression, IfElseStmt, IntValue, IntegerType, LTEExpression, LTExpression, MultExpression, NEQExpression, OberonModule, OrExpression, Procedure, ProcedureCallStmt, RangeCase, ReadIntStmt, ReturnStmt, SequenceStmt, SimpleCase, Statement, SubExpression, Type, Undef, UndefinedType, VarExpression, VariableDeclaration, WhileStmt, WriteStmt}
 import br.unb.cic.oberon.environment.Environment
 import br.unb.cic.oberon.visitor.{OberonVisitor, OberonVisitorAdapter}
 
@@ -61,6 +61,7 @@ class TypeChecker extends OberonVisitorAdapter {
     case IfElseStmt(_, _, _) => visitIfElseStmt(stmt)
     case WhileStmt(_, _) => visitWhileStmt(stmt)
     case ProcedureCallStmt(_, _) => procedureCallStmt(stmt)
+    case CaseStmt(_, _, _) => visitSwitchStmt(stmt)
     case SequenceStmt(stmts) => stmts.flatMap(s => s.accept(this))
     case ReturnStmt(exp) => if(exp.accept(expVisitor).isDefined) List() else List((stmt, s"Expression $exp is ill typed."))
     case ReadIntStmt(v) => if(env.lookup(v).isDefined) List() else List((stmt, s"Variable $v not declared."))
@@ -93,6 +94,42 @@ class TypeChecker extends OberonVisitorAdapter {
         stmt.accept(this)
       }
       else List((stmt, s"Expression $condition do not have a boolean type"))
+  }
+
+  private def visitSwitchStmt(stmt: Statement) = stmt match {
+    case CaseStmt(exp, cases, elseStmt) =>
+      if(exp.accept(expVisitor).contains(IntegerType)){
+      var list2 = List[(br.unb.cic.oberon.ast.Statement, String)]()
+        cases.foreach (c =>     
+          c match {
+            case SimpleCase(condition, stmt1) =>
+              if(condition.accept(expVisitor).contains(IntegerType)) {
+                val list1 = stmt1.accept(this)
+                list1
+              }
+              else {
+                val list1 = List((stmt, s"Case value $condition does not have an integer type"))
+                list2 = list1 ++ list2
+                
+              }
+
+            case RangeCase(min, max, stmt2) =>
+              if(min.accept(expVisitor).contains(IntegerType) && max.accept(expVisitor).contains(IntegerType)){
+                val list1 = stmt2.accept(this)
+                list1
+              }
+              else {
+                val list1 = List((stmt, s"Min $min or max $max does not have an integer type"))
+                list2 ++ list1
+              } 
+          }
+
+        )
+        
+        val list3 = if(elseStmt.isDefined) elseStmt.get.accept(this) else List()
+        list2 ++ list3
+      }
+      else List((stmt, s"Expression $exp does not have an integer type"))
   }
 
   /*

--- a/src/main/scala/br/unb/cic/oberon/tc/TypeChecker.scala
+++ b/src/main/scala/br/unb/cic/oberon/tc/TypeChecker.scala
@@ -1,6 +1,6 @@
 package br.unb.cic.oberon.tc
 
-import br.unb.cic.oberon.ast.{AddExpression, AndExpression, AssignmentStmt, BoolValue, BooleanType, Brackets, Constant, DivExpression, EQExpression, Expression, FormalArg, ForStmt, GTEExpression, GTExpression, IfElseStmt, IntValue, IntegerType, LTEExpression, LTExpression, MultExpression, NEQExpression, OberonModule, OrExpression, Procedure, ProcedureCallStmt, ReadIntStmt, ReturnStmt, SequenceStmt, Statement, SubExpression, Type, Undef, UndefinedType, VarExpression, VariableDeclaration, WhileStmt, WriteStmt}
+import br.unb.cic.oberon.ast.{AddExpression, AndExpression, AssignmentStmt, BoolValue, BooleanType, Brackets, Constant, DivExpression, EQExpression, Expression, FormalArg, ForStmt, GTEExpression, GTExpression, IfElseStmt, IntValue, IntegerType, LTEExpression, LTExpression, MultExpression, NEQExpression, OberonModule, OrExpression, Procedure, ProcedureCallStmt, ReadIntStmt, ReturnStmt, SequenceStmt, Statement, SubExpression, Type, Undef, UndefinedType, VarExpression, VariableDeclaration, WhileStmt, WriteStmt, RangeCase, SimpleCase, CaseStmt}
 import br.unb.cic.oberon.environment.Environment
 import br.unb.cic.oberon.visitor.{OberonVisitor, OberonVisitorAdapter}
 

--- a/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
+++ b/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
@@ -2,7 +2,7 @@ package br.unb.cic.oberon.tc
 
 import java.nio.file.{Files, Paths}
 
-import br.unb.cic.oberon.ast.{AddExpression, AssignmentStmt, BoolValue, BooleanType, ForStmt, IfElseStmt, IntValue, IntegerType, ReadIntStmt, SequenceStmt, Undef, VarExpression, WhileStmt, WriteStmt}
+import br.unb.cic.oberon.ast.{AddExpression, AssignmentStmt, BoolValue, BooleanType, ForStmt, IfElseStmt, IntValue, IntegerType, ReadIntStmt, SequenceStmt, Undef, VarExpression, WhileStmt, WriteStmt, CaseStmt, RangeCase,SimpleCase}
 import br.unb.cic.oberon.parser.OberonParser.ReadIntStmtContext
 import br.unb.cic.oberon.parser.ScalaParser
 import org.scalatest.funsuite.AnyFunSuite

--- a/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
+++ b/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
@@ -140,6 +140,125 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt02.accept(visitor).size == 0)
   }
 
+  test("Test switch-case statement type checker Range-case (invalid case01) ") {
+    val visitor = new TypeChecker()
+    
+    val stmt01 = AssignmentStmt("x", IntValue(10))
+    val stmt02 = AssignmentStmt("y", IntValue(15))
+    visitor.env.setGlobalVariable("x", IntegerType)
+    visitor.env.setGlobalVariable("y", IntegerType)
+
+    val caseElse = AssignmentStmt("x", IntValue(20))
+    
+
+    val case01 = RangeCase(BoolValue(false), IntValue(20), stmt01)
+    val case02 = RangeCase(IntValue(21), IntValue(30), stmt02)
+
+    val cases = List(case01, case02)
+    
+    val stmt03 = CaseStmt(IntValue(11), cases, Some(caseElse))
+
+    assert(stmt01.accept(visitor) == List())
+    assert(stmt02.accept(visitor) == List())
+    assert(caseElse.accept(visitor) == List())
+    assert(stmt03.accept(visitor).size == 1)
+  }
+
+  test("Test switch-case statement type checker Range-case (invalid case02) ") {
+    val visitor = new TypeChecker()
+    
+    val stmt01 = AssignmentStmt("x", IntValue(10))
+    val stmt02 = AssignmentStmt("y", IntValue(15))
+    visitor.env.setGlobalVariable("x", IntegerType)
+    visitor.env.setGlobalVariable("y", IntegerType)
+
+    val caseElse = AssignmentStmt("x", IntValue(20))
+    
+
+    val case01 = RangeCase(IntValue(21), IntValue(20), stmt01)
+    val case02 = RangeCase(BoolValue(false), IntValue(30), stmt02)
+
+    val cases = List(case01, case02)
+    
+    val stmt03 = CaseStmt(IntValue(11), cases, Some(caseElse))
+
+    assert(stmt01.accept(visitor) == List())
+    assert(stmt02.accept(visitor) == List())
+    assert(caseElse.accept(visitor) == List())
+    assert(stmt03.accept(visitor).size == 1)
+  }
+
+  test("Test switch-case statement type checker Range-case (invalid case01 and case02) ") {
+    val visitor = new TypeChecker()
+    
+    val stmt01 = AssignmentStmt("x", IntValue(10))
+    val stmt02 = AssignmentStmt("y", IntValue(15))
+    visitor.env.setGlobalVariable("x", IntegerType)
+    visitor.env.setGlobalVariable("y", IntegerType)
+
+    val caseElse = AssignmentStmt("x", IntValue(20))
+    
+
+    val case01 = RangeCase(BoolValue(false), IntValue(20), stmt01)
+    val case02 = RangeCase(BoolValue(false), IntValue(30), stmt02)
+
+    val cases = List(case01, case02)
+    
+    val stmt03 = CaseStmt(IntValue(11), cases, Some(caseElse))
+
+    assert(stmt01.accept(visitor) == List())
+    assert(stmt02.accept(visitor) == List())
+    assert(caseElse.accept(visitor) == List())
+    assert(stmt03.accept(visitor).size == 2)
+  }
+
+  test("Test switch-case statement type checker Range-case (invalid case01 and case02 second parameter) ") {
+    val visitor = new TypeChecker()
+    
+    val stmt01 = AssignmentStmt("x", IntValue(10))
+    val stmt02 = AssignmentStmt("y", IntValue(15))
+    visitor.env.setGlobalVariable("x", IntegerType)
+    visitor.env.setGlobalVariable("y", IntegerType)
+
+    val caseElse = AssignmentStmt("x", IntValue(20))
+    
+
+    val case01 = RangeCase(IntValue(20),BoolValue(false), stmt01)
+    val case02 = RangeCase(IntValue(30),BoolValue(false), stmt02)
+
+    val cases = List(case01, case02)
+    
+    val stmt03 = CaseStmt(IntValue(11), cases, Some(caseElse))
+
+    assert(stmt01.accept(visitor) == List())
+    assert(stmt02.accept(visitor) == List())
+    assert(caseElse.accept(visitor) == List())
+    assert(stmt03.accept(visitor).size == 2)
+  }
+
+  test("Test switch-case statement type checker Range-case (invalid CaseStmt exp) ") {
+    val visitor = new TypeChecker()
+    
+    val stmt01 = AssignmentStmt("x", IntValue(10))
+    val stmt02 = AssignmentStmt("y", IntValue(15))
+    visitor.env.setGlobalVariable("x", IntegerType)
+    visitor.env.setGlobalVariable("y", IntegerType)
+
+    val caseElse = AssignmentStmt("x", IntValue(20))
+    
+
+    val case01 = RangeCase(IntValue(20),IntValue(30), stmt01)
+    val case02 = RangeCase(IntValue(30),IntValue(40), stmt02)
+
+    val cases = List(case01, case02)
+    
+    val stmt03 = CaseStmt(Undef(), cases, Some(caseElse))
+
+    assert(stmt01.accept(visitor) == List())
+    assert(stmt02.accept(visitor) == List())
+    assert(caseElse.accept(visitor) == List())
+    assert(stmt03.accept(visitor).size == 1)
+  }
 
   test("Test switch-case statement type checker (invalid bool condition)") {
     val visitor = new TypeChecker()
@@ -161,7 +280,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt02.accept(visitor).size ==  1)
   }
 
-  test("Test switch-case statement type checker (invalid case01 condition)") {
+  test("Test switch-case statement type checker (invalid case02 condition)") {
     val visitor = new TypeChecker()
     
     val stmt01 = AssignmentStmt("x", IntValue(10))
@@ -190,7 +309,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     val caseElse = AssignmentStmt("x", IntValue(20))
     
 
-    val case01 = SimpleCase(IntValue(10), stmt01)
+    val case01 = SimpleCase(Undef(), stmt01)
     val case02 = SimpleCase(Undef(), stmt01)
     val cases = List(case01, case02)
     
@@ -198,7 +317,31 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
 
     assert(stmt01.accept(visitor) == List())
     assert(caseElse.accept(visitor) == List())
-    assert(stmt02.accept(visitor).size ==  1)
+    assert(stmt02.accept(visitor).size ==  2)
+  }
+
+  test("Test switch-case statement type checker Range-case correct") {
+    val visitor = new TypeChecker()
+    
+    val stmt01 = AssignmentStmt("x", IntValue(10))
+    val stmt02 = AssignmentStmt("y", IntValue(15))
+    visitor.env.setGlobalVariable("x", IntegerType)
+    visitor.env.setGlobalVariable("y", IntegerType)
+
+    val caseElse = AssignmentStmt("x", IntValue(20))
+    
+
+    val case01 = RangeCase(IntValue(10), IntValue(20), stmt01)
+    val case02 = RangeCase(IntValue(21), IntValue(30), stmt02)
+
+    val cases = List(case01, case02)
+    
+    val stmt03 = CaseStmt(IntValue(11), cases, Some(caseElse))
+
+    assert(stmt01.accept(visitor) == List())
+    assert(stmt02.accept(visitor) == List())
+    assert(caseElse.accept(visitor) == List())
+    assert(stmt03.accept(visitor) == List())
   }
 
    test("Test switch-case statement type checker") {

--- a/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
+++ b/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
@@ -140,7 +140,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt02.accept(visitor).size == 0)
   }
 
-  test("Test switch-case statement type checker Range-case (invalid case01) ") {
+  test("Test switch-case statement type checker RangeCase (invalid case01 min expression) ") {
     val visitor = new TypeChecker()
     
     val stmt01 = AssignmentStmt("x", IntValue(10))
@@ -164,7 +164,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt03.accept(visitor).size == 1)
   }
 
-  test("Test switch-case statement type checker Range-case (invalid case02) ") {
+  test("Test switch-case statement type checker RangeCase (invalid case02 min expression) ") {
     val visitor = new TypeChecker()
     
     val stmt01 = AssignmentStmt("x", IntValue(10))
@@ -188,7 +188,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt03.accept(visitor).size == 1)
   }
 
-  test("Test switch-case statement type checker Range-case (invalid case01 and case02) ") {
+  test("Test switch-case statement type checker RangeCase (invalid case01 and case02 min expression) ") {
     val visitor = new TypeChecker()
     
     val stmt01 = AssignmentStmt("x", IntValue(10))
@@ -212,7 +212,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt03.accept(visitor).size == 2)
   }
 
-  test("Test switch-case statement type checker Range-case (invalid case01 and case02 second parameter) ") {
+  test("Test switch-case statement type checker RangeCase (invalid case01 and case02 max expression) ") {
     val visitor = new TypeChecker()
     
     val stmt01 = AssignmentStmt("x", IntValue(10))
@@ -236,7 +236,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt03.accept(visitor).size == 2)
   }
 
-  test("Test switch-case statement type checker Range-case (invalid CaseStmt exp) ") {
+  test("Test switch-case statement type checker RangeCase (invalid CaseStmt exp) ") {
     val visitor = new TypeChecker()
     
     val stmt01 = AssignmentStmt("x", IntValue(10))
@@ -260,7 +260,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt03.accept(visitor).size == 1)
   }
 
-  test("Test switch-case statement type checker (invalid bool condition)") {
+  test("Test switch-case statement type checker SimpleCase (invalid CaseStmt condition)") {
     val visitor = new TypeChecker()
     
     val stmt01 = AssignmentStmt("x", IntValue(10))
@@ -280,7 +280,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt02.accept(visitor).size ==  1)
   }
 
-  test("Test switch-case statement type checker (invalid case02 condition)") {
+  test("Test switch-case statement type checker SimpleCase (invalid case02 condition)") {
     val visitor = new TypeChecker()
     
     val stmt01 = AssignmentStmt("x", IntValue(10))
@@ -300,7 +300,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt02.accept(visitor).size ==  1)
   }
 
-  test("Test switch-case statement type checker (invalid case01 and case02 condition)") {
+  test("Test switch-case statement type checker SimpleCase (invalid case01 and case02 condition)") {
     val visitor = new TypeChecker()
     
     val stmt01 = AssignmentStmt("x", IntValue(10))
@@ -320,7 +320,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt02.accept(visitor).size ==  2)
   }
 
-  test("Test switch-case statement type checker Range-case correct") {
+  test("Test switch-case statement type checker RangeCase") {
     val visitor = new TypeChecker()
     
     val stmt01 = AssignmentStmt("x", IntValue(10))
@@ -344,7 +344,7 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     assert(stmt03.accept(visitor) == List())
   }
 
-   test("Test switch-case statement type checker") {
+  test("Test switch-case statement type checker SimpleCase") {
     val visitor = new TypeChecker()
     
     val stmt01 = AssignmentStmt("x", IntValue(10))

--- a/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
+++ b/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
@@ -2,7 +2,7 @@ package br.unb.cic.oberon.tc
 
 import java.nio.file.{Files, Paths}
 
-import br.unb.cic.oberon.ast.{AddExpression, AssignmentStmt, BoolValue, BooleanType, IfElseStmt, IntValue, IntegerType, ReadIntStmt, SequenceStmt, Undef, VarExpression, WhileStmt, WriteStmt}
+import br.unb.cic.oberon.ast.{AddExpression, AssignmentStmt, BoolValue, BooleanType, IfElseStmt, IntValue, IntegerType, ReadIntStmt, SequenceStmt, Undef, VarExpression, WhileStmt, WriteStmt, CaseStmt,SimpleCase, CaseAlternative, RangeCase}
 import br.unb.cic.oberon.parser.OberonParser.ReadIntStmtContext
 import br.unb.cic.oberon.parser.ScalaParser
 import org.scalatest.funsuite.AnyFunSuite
@@ -138,6 +138,87 @@ class TypeCheckerTestSuite  extends AnyFunSuite {
     val stmt02 = WhileStmt(BoolValue(true), stmt01)
     assert(stmt01.accept(visitor).size == 0)
     assert(stmt02.accept(visitor).size == 0)
+  }
+
+
+  test("Test switch-case statement type checker (invalid bool condition)") {
+    val visitor = new TypeChecker()
+    
+    val stmt01 = AssignmentStmt("x", IntValue(10))
+    visitor.env.setGlobalVariable("x", IntegerType)
+
+    val caseElse = AssignmentStmt("x", IntValue(20))
+    
+
+    val case01 = SimpleCase(BoolValue(true), stmt01)
+    val case02 = SimpleCase(BoolValue(false), stmt01)
+    val cases = List(case01, case02)
+    
+    val stmt02 = CaseStmt(BoolValue(true), cases, Some(caseElse))
+
+    assert(stmt01.accept(visitor) == List())
+    assert(caseElse.accept(visitor) == List())
+    assert(stmt02.accept(visitor).size ==  1)
+  }
+
+  test("Test switch-case statement type checker (invalid case01 condition)") {
+    val visitor = new TypeChecker()
+    
+    val stmt01 = AssignmentStmt("x", IntValue(10))
+    visitor.env.setGlobalVariable("x", IntegerType)
+
+    val caseElse = AssignmentStmt("x", IntValue(20))
+    
+
+    val case01 = SimpleCase(IntValue(10), stmt01)
+    val case02 = SimpleCase(BoolValue(false), stmt01)
+    val cases = List(case01, case02)
+    
+    val stmt02 = CaseStmt(IntValue(10), cases, Some(caseElse))
+
+    assert(stmt01.accept(visitor) == List())
+    assert(caseElse.accept(visitor) == List())
+    assert(stmt02.accept(visitor).size ==  1)
+  }
+
+  test("Test switch-case statement type checker (invalid case01 and case02 condition)") {
+    val visitor = new TypeChecker()
+    
+    val stmt01 = AssignmentStmt("x", IntValue(10))
+    visitor.env.setGlobalVariable("x", IntegerType)
+
+    val caseElse = AssignmentStmt("x", IntValue(20))
+    
+
+    val case01 = SimpleCase(IntValue(10), stmt01)
+    val case02 = SimpleCase(Undef(), stmt01)
+    val cases = List(case01, case02)
+    
+    val stmt02 = CaseStmt(IntValue(10), cases, Some(caseElse))
+
+    assert(stmt01.accept(visitor) == List())
+    assert(caseElse.accept(visitor) == List())
+    assert(stmt02.accept(visitor).size ==  1)
+  }
+
+   test("Test switch-case statement type checker") {
+    val visitor = new TypeChecker()
+    
+    val stmt01 = AssignmentStmt("x", IntValue(10))
+    visitor.env.setGlobalVariable("x", IntegerType)
+
+    val caseElse = AssignmentStmt("x", IntValue(20))
+    
+
+    val case01 = SimpleCase(IntValue(10), stmt01)
+    val case02 = SimpleCase(IntValue(20), stmt01)
+    val cases = List(case01, case02)
+    
+    val stmt02 = CaseStmt(IntValue(10), cases, Some(caseElse))
+
+    assert(stmt01.accept(visitor) == List())
+    assert(caseElse.accept(visitor) == List())
+    assert(stmt02.accept(visitor) == List())
   }
 
   /*


### PR DESCRIPTION
Professor, esse PR tenta adicionar o type checker do Switch-Case. Eu tentei fazer o merge, mas ao rodar os testes, o terminal me devolvia um erro de Match em todos os testes que escrevemos. Por exemplo: 

`Test switch-case statement type checker *** FAILED ***
[info]   scala.MatchError: CaseStmt(IntValue(10),List(SimpleCase(IntValue(10),AssignmentStmt(x,IntValue(10))), SimpleCase(IntValue(20),AssignmentStmt(x,IntValue(10)))),Some(AssignmentStmt(x,IntValue(20)))) (of class br.unb.cic.oberon.ast.CaseStmt)
[info]   at br.unb.cic.oberon.tc.TypeChecker.visit(TypeChecker.scala:59)
[info]   at br.unb.cic.oberon.tc.TypeChecker.visit(TypeChecker.scala:42)
[info]   at br.unb.cic.oberon.ast.Statement.accept(OberonModule.scala:69)
[info]   at br.unb.cic.oberon.ast.Statement.accept$(OberonModule.scala:69)
[info]   at br.unb.cic.oberon.ast.CaseStmt.accept(OberonModule.scala:81)
[info]   at br.unb.cic.oberon.tc.TypeCheckerTestSuite.$anonfun$new$19(TypeCheckerTestSuite.scala:275)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   ...
`

Não consegui entender de onde vinha esse erro, uma vez que antes de fazer o merge todos os testes estavam passando sem problema.