### PR TITLE
Added Support for the "For" Statement with Range

### DIFF
--- a/src/main/antlr4/Oberon.g4
+++ b/src/main/antlr4/Oberon.g4
@@ -59,6 +59,7 @@ statement
  | 'IF' cond = expression 'THEN' thenStmt = statement ('ELSE' elseStmt = statement)? 'END'                                    #IfElseStmt
  | 'WHILE' cond = expression 'DO' stmt = statement 'END'                                                                      #WhileStmt
  | 'FOR' init = statement 'TO' condition = expression 'DO' stmt = statement 'END'                                             #ForStmt
+ | 'FOR' var = Id 'IN' min = expression '..' max = expression 'DO' stmt = statement 'END'                                     #ForRangeStmt
  | 'RETURN' exp = expression                                                                                                  #ReturnStmt
  | 'CASE' exp = expression 'OF' cases += caseAlternative ('|' cases += caseAlternative)* ('ELSE' elseStmt= statement)? 'END'  #CaseStmt
  ;

--- a/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
+++ b/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
@@ -298,7 +298,39 @@ class ParserVisitor {
 
       stmt = ForStmt(init, condition, block)
     }
-   
+
+    override def visitForRangeStmt(ctx: OberonParser.ForRangeStmtContext): Unit = {
+      val visitor = new ExpressionVisitor()
+
+      val varName = ctx.`var`.getText
+      val variable = VarExpression(varName)
+
+      ctx.min.accept(visitor)
+      val rangeMin = visitor.exp
+      
+      ctx.max.accept(visitor)
+      val rangeMax = visitor.exp
+
+      ctx.stmt.accept(this)
+      val block = stmt
+
+      // Instantiating the values for the basic ForStmt
+      
+      // var := rangeMin
+      val init = AssignmentStmt(variable.name, rangeMin)
+
+      // var <= rangeMax
+      val condition = LTEExpression(variable, rangeMax)
+      
+      // var := var + 1
+      val accumulator = AssignmentStmt(variable.name, AddExpression(variable, IntValue(1)))
+
+      // stmt; var := var + 1
+      val realBlock = SequenceStmt(List(block, accumulator))
+
+      stmt = ForStmt(init, condition, realBlock)
+    }
+
     override def visitReturnStmt(ctx: OberonParser.ReturnStmtContext): Unit = {
       val visitor = new ExpressionVisitor()
       ctx.exp.accept(visitor)

--- a/src/test/resources/stmts/stmt25.oberon
+++ b/src/test/resources/stmts/stmt25.oberon
@@ -1,0 +1,14 @@
+MODULE ForRangeModule;
+
+VAR
+  x : INTEGER;
+
+BEGIN
+
+  FOR x IN 0 .. 10 DO
+    write(x)
+  END
+    
+END
+
+END ForRangeModule. 

--- a/src/test/resources/stmts/stmt26.oberon
+++ b/src/test/resources/stmts/stmt26.oberon
@@ -1,0 +1,17 @@
+MODULE ForRangeModule;
+
+VAR
+  x, min, max : INTEGER;
+
+BEGIN
+
+  readInt(min);
+  readInt(max);
+
+  FOR x IN min .. max DO
+    write(x)
+  END
+    
+END
+
+END ForRangeModule. 

--- a/src/test/resources/stmts/stmt27.oberon
+++ b/src/test/resources/stmts/stmt27.oberon
@@ -1,0 +1,16 @@
+MODULE ForRangeModule;
+
+VAR
+  x, y : INTEGER;
+
+BEGIN
+
+  FOR x IN 0 .. 20 DO
+    FOR y IN x .. 20 DO
+      write(y)
+    END
+  END
+    
+END
+
+END ForRangeModule.

--- a/src/test/resources/stmts/stmt28.oberon
+++ b/src/test/resources/stmts/stmt28.oberon
@@ -1,0 +1,19 @@
+MODULE ForRangeModule;
+
+VAR
+  x, y, min, max : INTEGER;
+
+BEGIN
+
+  readInt(min);
+  readInt(max);
+
+  FOR x IN min .. max DO
+    FOR y IN x .. max DO
+      write(y)
+    END
+  END
+    
+END
+
+END ForRangeModule.

--- a/src/test/resources/stmts/stmt29.oberon
+++ b/src/test/resources/stmts/stmt29.oberon
@@ -1,0 +1,19 @@
+MODULE ForRangeModule;
+
+VAR
+  x : INTEGER;
+
+PROCEDURE squareOf(n : INTEGER) : INTEGER;
+ BEGIN
+   RETURN n * n
+ END squareOf
+
+BEGIN
+
+  FOR x IN 0 .. 10 DO
+    write(squareOf(x))
+  END
+    
+END
+
+END ForRangeModule. 


### PR DESCRIPTION
(Grupo 6) Adicionamos a implementação do for statement com range pro parser. Nosso grupo teve dificuldade pra proceder, pois não queriamos modificar e acabar "quebrando" o que já tava feito. Por isso, repetimos uma regra para o for (só que com a sintaxe pra usar com o range). Não é a melhor forma, mas acreditamos que não vai impactar tanto as outras partes do projeto. De qualquer modo, eu agradeço qualquer feedback professor.