### PR TITLE
Added support for Array and Record types declarations in the Parser

### DIFF
--- a/src/main/antlr4/Oberon.g4
+++ b/src/main/antlr4/Oberon.g4
@@ -5,9 +5,14 @@ compilationUnit
   ;  
 
 declarations
-  : ('CONST' constant+)? ('VAR' varDeclaration+)? procedure*
+  : ('TYPE' userTypeDeclaration+) ? ('CONST' constant+)? ('VAR' varDeclaration+)? procedure*
   ;
-  
+
+userTypeDeclaration
+  : nameType = Id '=' ('ARRAY' length = INT 'OF' vartype = oberonType)      #ArrayTypeDeclaration
+  | nameType = Id '=' ('RECORD' (vars += varDeclaration)+ 'END')            #RecordTypeDeclaration
+  ;
+
 constant
   : constName = Id '=' exp = expression ';'
   ;
@@ -57,7 +62,7 @@ statement
  | 'write' '(' expression ')'                                                                                                 #WriteStmt
  | name = Id '(' arguments? ')'                                                                                               #ProcedureCall
  | 'IF' cond = expression 'THEN' thenStmt = statement ('ELSE' elseStmt = statement)? 'END'                                    #IfElseStmt
- | 'IF' cond = expression 'THEN' thenStmt = statement ('ELSIF' elsifs += elseIfStmt)+ ('ELSE' elseStmt = statement)? 'END'                                 #IfElseIfStmt
+ | 'IF' cond = expression 'THEN' thenStmt = statement ('ELSIF' elsifs += elseIfStmt)+ ('ELSE' elseStmt = statement)? 'END'    #IfElseIfStmt
  | 'WHILE' cond = expression 'DO' stmt = statement 'END'                                                                      #WhileStmt
  | 'REPEAT' stmt = statement 'UNTIL' cond = expression                                                                        #RepeatUntilStmt
  | 'FOR' init = statement 'TO' condition = expression 'DO' stmt = statement 'END'                                             #ForStmt
@@ -81,8 +86,9 @@ intValue : INT ;
 boolValue: TRUE | FALSE ;
 
 oberonType
- : 'INTEGER'
- | 'BOOLEAN'
+ : 'INTEGER'         #IntegerType
+ | 'BOOLEAN'         #BooleanType
+ | name = Id         #ReferenceType        // Reference for user defined types
  ;
 
 INT : Digit+;

--- a/src/main/scala/br/unb/cic/oberon/ast/OberonModule.scala
+++ b/src/main/scala/br/unb/cic/oberon/ast/OberonModule.scala
@@ -7,6 +7,7 @@ case class OberonModule(name: String,
                         constants: List[Constant],
                         variables: List[VariableDeclaration],
                         procedures: List[Procedure],
+                        userTypes: List[UserDefinedType],
                         stmt: Option[Statement]
                        ) {
   def accept(v: OberonVisitor): Unit = v.visit(this)
@@ -98,3 +99,11 @@ trait Type {
 case object IntegerType extends Type
 case object BooleanType extends Type
 case object UndefinedType extends Type
+case class ReferenceToUserDefinedType(name: String) extends Type
+
+trait UserDefinedType{
+  def accept(v: OberonVisitor) = v.visit(this)
+} 
+
+case class RecordType(name: String, variables: List[VariableDeclaration]) extends UserDefinedType
+case class ArrayType(name: String, length: Int, variableType: Type) extends UserDefinedType

--- a/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
+++ b/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
@@ -39,9 +39,10 @@ class ParserVisitor {
     val constants = ctx.declarations().constant().asScala.toList.map(c => visitConstant(c))
     val variables = ctx.declarations().varDeclaration().asScala.toList.map(v => visitVariableDeclaration(v)).flatten
     val procedures = ctx.declarations().procedure().asScala.toList.map(p => visitProcedureDeclaration(p))
+    val userTypes = ctx.declarations().userTypeDeclaration().asScala.toList.map(t => visitUserDefinedType(t))
     val block = visitModuleBlock(ctx.block())
 
-    module = OberonModule(name.getText, constants, variables, procedures, block)
+    module = OberonModule(name.getText, constants, variables, procedures, userTypes, block)
   }
 
   /**
@@ -103,6 +104,12 @@ class ParserVisitor {
     ctx.args.asScala.toList.map(arg => FormalArg(arg.getText, argType))
   }
 
+  def visitUserDefinedType(ctx: OberonParser.UserTypeDeclarationContext): UserDefinedType = {
+    val userTypeVisitor = new UserDefinedTypeVisitor()
+
+    ctx.accept(userTypeVisitor)
+    userTypeVisitor.uType
+  }
 
   /**
    * Visit an oberon type.
@@ -113,12 +120,26 @@ class ParserVisitor {
    * @param ctx the oberon type context
    * @return a oberon type representation.
    */
-  def visitOberonType(ctx: OberonParser.OberonTypeContext): Type =
-    ctx.getText match {
-      case "INTEGER" => IntegerType
-      case "BOOLEAN" => BooleanType
-      case _ => UndefinedType
+  def visitOberonType(ctx: OberonParser.OberonTypeContext): Type = {
+    val typeVisitor = new OberonTypeVisitor()
+    ctx.accept(typeVisitor)
+
+    if(typeVisitor.baseType == null) UndefinedType else typeVisitor.baseType
+  }
+
+  class OberonTypeVisitor extends OberonBaseVisitor[Unit] {
+    var baseType: Type = _
+
+    override def visitIntegerType(ctx: OberonParser.IntegerTypeContext): Unit =
+      baseType = IntegerType
+      
+    override def visitBooleanType(ctx: OberonParser.BooleanTypeContext): Unit = { baseType = BooleanType }
+ 
+    override def visitReferenceType(ctx: OberonParser.ReferenceTypeContext): Unit = {
+      val nameType = ctx.name.getText
+      baseType = ReferenceToUserDefinedType(nameType)
     }
+  }
 
   /* A visitor for parsing expressions */
   class ExpressionVisitor() extends OberonBaseVisitor[Unit] {
@@ -411,4 +432,33 @@ class ParserVisitor {
     }
   }
 
+  class UserDefinedTypeVisitor extends OberonBaseVisitor[Unit] {
+    var uType: UserDefinedType = _
+
+    override def visitRecordTypeDeclaration(ctx: OberonParser.RecordTypeDeclarationContext): Unit = {
+      val variablesList = new ListBuffer[VariableDeclaration]
+      val name = ctx.nameType.getText
+
+      ctx.vars.asScala.toList.foreach(variable => {
+        val varList = visitVariableDeclaration(variable)
+
+        varList.foreach(v => {
+          variablesList += v
+        })
+      })
+
+      uType = RecordType(name, variablesList.toList)
+    }
+
+    override def visitArrayTypeDeclaration(ctx: OberonParser.ArrayTypeDeclarationContext): Unit = {
+      val typeVisitor = new ParserVisitor()
+      
+      val nome = ctx.nameType.getText
+      val tamanho = ctx.length.getText.toInt
+      val variableType = typeVisitor.visitOberonType(ctx.vartype)
+
+      uType = ArrayType(nome, tamanho, variableType)
+    }
+
+  }
 }

--- a/src/main/scala/br/unb/cic/oberon/visitor/OberonVisitor.scala
+++ b/src/main/scala/br/unb/cic/oberon/visitor/OberonVisitor.scala
@@ -1,6 +1,6 @@
 package br.unb.cic.oberon.visitor
 
-import br.unb.cic.oberon.ast.{Constant, Expression, FormalArg, OberonModule, Procedure, Statement, Type, VariableDeclaration, CaseAlternative}
+import br.unb.cic.oberon.ast.{Constant, Expression, FormalArg, OberonModule, Procedure, Statement, Type, VariableDeclaration, CaseAlternative, UserDefinedType}
 
 /**
  * The abstract definition of an Oberon Visitor.
@@ -24,6 +24,7 @@ trait OberonVisitor {
   def visit(stmt: Statement) : T
   def visit(aType: Type): T
   def visit(caseAlt: CaseAlternative): T
+  def visit(userType: UserDefinedType): T
 }
 
 abstract class OberonVisitorAdapter extends OberonVisitor {
@@ -36,4 +37,5 @@ abstract class OberonVisitorAdapter extends OberonVisitor {
   override def visit(stmt: Statement): T = ???
   override def visit(aType: Type): T = ???
   override def visit(caseAlt: CaseAlternative): T = ???
+  override def visit(userType: UserDefinedType): T = ???
 }

--- a/src/test/resources/stmts/stmt32.oberon
+++ b/src/test/resources/stmts/stmt32.oberon
@@ -1,0 +1,22 @@
+MODULE UserTypeModule;
+
+TYPE
+  type1 = ARRAY 10 OF INTEGER
+  
+  type2 = RECORD 
+    lista: type1;
+    inteiro: INTEGER
+  END
+  
+  type3 = RECORD
+    mylist: type2;
+    age: INTEGER;
+    check: BOOLEAN;
+    kleber, bolo: type1
+  END
+
+  type4 = RECORD
+    v1, v2: INTEGER
+  END
+
+END UserTypeModule.

--- a/src/test/resources/stmts/stmt33.oberon
+++ b/src/test/resources/stmts/stmt33.oberon
@@ -1,0 +1,16 @@
+MODULE UserTypeModule;
+
+TYPE
+  tysize = ARRAY 5 OF INTEGER
+  
+  shoes = RECORD
+    id: INTEGER;
+    sizes: tysize;
+    price: INTEGER;
+    stock: INTEGER;
+    limited: BOOLEAN
+  END
+
+  shoes_array = ARRAY 50 OF shoes
+
+END UserTypeModule.

--- a/src/test/resources/stmts/stmt34.oberon
+++ b/src/test/resources/stmts/stmt34.oberon
@@ -1,0 +1,16 @@
+MODULE UserTypeModule;
+
+TYPE
+  m_id = ARRAY 15 OF INTEGER
+
+  team = RECORD
+    t_id: INTEGER;
+    members: m_id;
+    n_members: INTEGER;
+    full: BOOLEAN
+  END
+  
+  team_array = ARRAY 20 OF team
+  test_array = ARRAY 20 OF INTEGER
+  second_test = ARRAY 20 OF test_array
+END UserTypeModule.

--- a/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
@@ -1509,4 +1509,114 @@ class ParserTestSuite extends AnyFunSuite {
 
     assert(stmt.stmts(2).isInstanceOf[RepeatUntilStmt])
   }
+
+  test("Testing the oberon stmt32 code. This module has some user types declarations") {
+    val path = Paths.get(getClass.getClassLoader.getResource("stmts/stmt32.oberon").getFile)
+
+    assert(path != null)
+
+    val content = String.join("\n", Files.readAllLines(path))
+    val module = ScalaParser.parse(content)
+
+    assert(module.name == "UserTypeModule")
+
+    assert(module.userTypes.length == 4)
+
+    val typeList = module.userTypes
+
+    val type1 = ArrayType("type1", 10, IntegerType)
+    
+    val type2 = RecordType("type2", List(VariableDeclaration("lista",  ReferenceToUserDefinedType("type1")),
+      VariableDeclaration("inteiro", IntegerType)))
+    
+    val type3 = RecordType("type3", List(
+      VariableDeclaration("mylist", ReferenceToUserDefinedType("type2")), 
+      VariableDeclaration("age", IntegerType),
+      VariableDeclaration("check", BooleanType),
+      VariableDeclaration("kleber", ReferenceToUserDefinedType("type1")),
+      VariableDeclaration("bolo", ReferenceToUserDefinedType("type1"))))
+      
+    val type4 = RecordType("type4", List(
+      VariableDeclaration("v1", IntegerType),
+      VariableDeclaration("v2", IntegerType)))
+
+    val typetoTest = List(type1, type2, type3, type4)
+
+    var it: Int = 0
+
+    typeList.foreach(t => {
+      assert(t == typetoTest(it))
+      it += 1
+    })
+
+  }
+
+  test("Testing the oberon stmt33 code. This module has a record and array type declarations"){
+    val path = Paths.get(getClass.getClassLoader.getResource("stmts/stmt33.oberon").getFile)
+
+    assert(path != null)
+
+    val content = String.join("\n", Files.readAllLines(path))
+    val module = ScalaParser.parse(content)
+
+    assert(module.name == "UserTypeModule")
+
+    assert(module.userTypes.length == 3)
+
+    val typeList = module.userTypes
+
+    val tysize = ArrayType("tysize", 5, IntegerType)
+    
+    val shoes = RecordType("shoes", List(VariableDeclaration("id", IntegerType), 
+      VariableDeclaration("sizes", ReferenceToUserDefinedType("tysize")),
+      VariableDeclaration("price", IntegerType),
+      VariableDeclaration("stock", IntegerType),
+      VariableDeclaration("limited", BooleanType)))
+
+    val shoes_array =  ArrayType("shoes_array", 50, ReferenceToUserDefinedType("shoes"))
+    
+    val typetoTest = List(tysize, shoes, shoes_array)
+
+    var it: Int = 0
+
+    typeList.foreach(t => {
+      assert(t == typetoTest(it))
+      it += 1
+    })
+  }
+
+  test("Testing the oberon stmt34 code. This module has a record and array type declarations"){
+    val path = Paths.get(getClass.getClassLoader.getResource("stmts/stmt34.oberon").getFile)
+
+    assert(path != null)
+
+    val content = String.join("\n", Files.readAllLines(path))
+    val module = ScalaParser.parse(content)
+
+    assert(module.name == "UserTypeModule")
+
+    assert(module.userTypes.length == 5)
+
+    val typeList = module.userTypes
+
+    val m_id = ArrayType("m_id", 15, IntegerType)
+    val team = RecordType("team", List( 
+      VariableDeclaration("t_id", IntegerType),
+      VariableDeclaration("members", ReferenceToUserDefinedType("m_id")),
+      VariableDeclaration("n_members", IntegerType),
+      VariableDeclaration("full", BooleanType)))
+
+    val team_array = ArrayType("team_array", 20, ReferenceToUserDefinedType("team"))
+    val test_array = ArrayType("test_array", 20, IntegerType)
+    val second_test = ArrayType("second_test", 20, ReferenceToUserDefinedType("test_array"))
+    val typetoTest = List(m_id, team, team_array, test_array, second_test)
+
+    var it: Int = 0
+
+    typeList.foreach(t => {
+      assert(t == typetoTest(it))
+      it += 1
+    })
+  }
+
 }


### PR DESCRIPTION
(Grupos 1 e 6) Adicionamos suporte para as declarações dos tipos Array e Record dentro do Parser, além de adicionar essas classes dentro da Ast. Também implementamos alguns testes.