### PR TITLE
Windows fix

### DIFF
--- a/src/test/resources/simple/simple01.oberon
+++ b/src/test/resources/simple/simple01.oberon
@@ -1,6 +1,6 @@
-MODULE SimpleModule;
+MODULE SimpleModule1;
 
 CONST
   x = 5;
 
-END SimpleModule.
+END SimpleModule1.

--- a/src/test/resources/simple/simple02.oberon
+++ b/src/test/resources/simple/simple02.oberon
@@ -1,4 +1,4 @@
-MODULE SimpleModule;
+MODULE SimpleModule2;
 
 CONST
   x = 5;
@@ -7,4 +7,4 @@ VAR
   abc : INTEGER;
   def : BOOLEAN;
 
-END SimpleModule.
+END SimpleModule2.

--- a/src/test/resources/simple/simple03.oberon
+++ b/src/test/resources/simple/simple03.oberon
@@ -1,4 +1,4 @@
-MODULE SimpleModule;
+MODULE SimpleModule3;
 
 CONST
   x = 5;
@@ -9,4 +9,4 @@ VAR
   abc : INTEGER;
   def : BOOLEAN;
 
-END SimpleModule.
+END SimpleModule3.

--- a/src/test/resources/simple/simple04.oberon
+++ b/src/test/resources/simple/simple04.oberon
@@ -1,4 +1,4 @@
-MODULE SimpleModule;
+MODULE SimpleModule4;
 
 CONST
   x = 5;
@@ -9,4 +9,4 @@ VAR
   abc : INTEGER;
   def : BOOLEAN;
 
-END SimpleModule.
+END SimpleModule4.

--- a/src/test/resources/simple/simple05.oberon
+++ b/src/test/resources/simple/simple05.oberon
@@ -1,4 +1,4 @@
-MODULE SimpleModule;
+MODULE SimpleModule5;
 
 CONST
   z = 5 * 10;
@@ -7,4 +7,4 @@ VAR
   abc : INTEGER;
   def : BOOLEAN;
 
-END SimpleModule.
+END SimpleModule5.

--- a/src/test/resources/simple/simple06.oberon
+++ b/src/test/resources/simple/simple06.oberon
@@ -1,4 +1,4 @@
-MODULE SimpleModule;
+MODULE SimpleModule6;
 
 CONST
   z = 5 + 10 * 3;
@@ -7,4 +7,4 @@ VAR
   abc : INTEGER;
   def : BOOLEAN;
 
-END SimpleModule.
+END SimpleModule6.

--- a/src/test/resources/simple/simple07.oberon
+++ b/src/test/resources/simple/simple07.oberon
@@ -1,4 +1,4 @@
-MODULE SimpleModule;
+MODULE SimpleModule7;
 
 CONST
   x = 5 + 10 * 3;
@@ -8,4 +8,4 @@ VAR
   abc : INTEGER;
   def : BOOLEAN;
 
-END SimpleModule.
+END SimpleModule7.

--- a/src/test/resources/simple/simple08.oberon
+++ b/src/test/resources/simple/simple08.oberon
@@ -1,4 +1,4 @@
-MODULE SimpleModule;
+MODULE SimpleModule8;
 
 CONST
   x = False;
@@ -9,4 +9,4 @@ VAR
   abc : INTEGER;
   def : BOOLEAN;
 
-END SimpleModule.
+END SimpleModule8.

--- a/src/test/resources/simple/simple09.oberon
+++ b/src/test/resources/simple/simple09.oberon
@@ -1,4 +1,4 @@
-MODULE SimpleModule;
+MODULE SimpleModule9;
 
 CONST
   z = True && False || False;
@@ -7,4 +7,4 @@ VAR
   abc : INTEGER;
   def : BOOLEAN;
 
-END SimpleModule.
+END SimpleModule9.

--- a/src/test/resources/simple/simple10.oberon
+++ b/src/test/resources/simple/simple10.oberon
@@ -1,4 +1,4 @@
-MODULE SimpleModule;
+MODULE SimpleModule10;
 
 VAR
   x : INTEGER;
@@ -7,4 +7,4 @@ BEGIN
 	x := (1 + 1)
 END
 
-END SimpleModule.
+END SimpleModule10.

--- a/src/test/resources/simple/simple11.oberon
+++ b/src/test/resources/simple/simple11.oberon
@@ -1,4 +1,4 @@
-MODULE SimpleModule;
+MODULE SimpleModule11;
 
 VAR
   x : CHAR;
@@ -7,4 +7,4 @@ BEGIN
 	x := 'a'
 END
 
-END SimpleModule.
+END SimpleModule11.

--- a/src/test/scala/br/unb/cic/oberon/codegen/JVMCodeGenTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/codegen/JVMCodeGenTest.scala
@@ -13,14 +13,14 @@ import jdk.internal.org.objectweb.asm._
 class JVMCodeGenTest extends AnyFunSuite {
 
   test("Generate code with fields of simple01.oberon") {
-    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple01.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple01.oberon").toURI)
 
     assert(path != null)
 
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule1")
     assert(module.variables.size == 0)
     assert(module.constants.size == 1)
 
@@ -46,14 +46,14 @@ class JVMCodeGenTest extends AnyFunSuite {
   }
 
   test("Generate code with fields of simple02.oberon") {
-    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple02.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple02.oberon").toURI)
 
     assert(path != null)
 
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule2")
     assert(module.variables.size == 2)
     assert(module.constants.size == 1)
 
@@ -79,14 +79,14 @@ class JVMCodeGenTest extends AnyFunSuite {
   }
 
  test("Generate code with fields of simple03.oberon") {
-    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple03.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple03.oberon").toURI)
 
     assert(path != null)
 
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule3")
     assert(module.variables.size == 2)
     assert(module.constants.size == 3)
 
@@ -112,14 +112,14 @@ class JVMCodeGenTest extends AnyFunSuite {
   }
 
   test("Generate code of simple04.oberon") {
-    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple04.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple04.oberon").toURI)
 
     assert(path != null)
 
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule4")
     assert(module.variables.size == 2)
     assert(module.constants.size == 3)
 
@@ -145,14 +145,14 @@ class JVMCodeGenTest extends AnyFunSuite {
   }
 
   test("Generate code of simple05.oberon") {
-    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple05.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple05.oberon").toURI)
 
     assert(path != null)
 
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule5")
     assert(module.variables.size == 2)
     assert(module.constants.size == 1)
 
@@ -178,14 +178,14 @@ class JVMCodeGenTest extends AnyFunSuite {
   }
 
   test("Generate code of simple06.oberon") {
-    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple06.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple06.oberon").toURI)
 
     assert(path != null)
 
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule6")
     assert(module.variables.size == 2)
     assert(module.constants.size == 1)
 
@@ -211,14 +211,14 @@ class JVMCodeGenTest extends AnyFunSuite {
   }
 
   test("Generate code of simple07.oberon") {
-    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple07.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple07.oberon").toURI)
 
     assert(path != null)
 
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule7")
     assert(module.variables.size == 2)
     assert(module.constants.size == 2)
 
@@ -244,14 +244,14 @@ class JVMCodeGenTest extends AnyFunSuite {
   }
 
   test("Generate code of simple08.oberon") {
-    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple08.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple08.oberon").toURI)
 
     assert(path != null)
 
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule8")
     assert(module.variables.size == 2)
     assert(module.constants.size == 3)
 
@@ -277,14 +277,14 @@ class JVMCodeGenTest extends AnyFunSuite {
   }
 
   test("Generate code of simple09.oberon") {
-    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple09.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple09.oberon").toURI)
 
     assert(path != null)
 
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule9")
     assert(module.variables.size == 2)
     assert(module.constants.size == 1)
 
@@ -310,14 +310,14 @@ class JVMCodeGenTest extends AnyFunSuite {
   }
 
   test("Generate code of simple10.oberon") {
-    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple10.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("simple/simple10.oberon").toURI)
 
     assert(path != null)
 
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule10")
     assert(module.variables.size == 1)
     assert(module.constants.size == 0)
 

--- a/src/test/scala/br/unb/cic/oberon/interpreter/NewTypes.scala
+++ b/src/test/scala/br/unb/cic/oberon/interpreter/NewTypes.scala
@@ -13,7 +13,7 @@ class NewTypesTest extends AnyFunSuite{
   interpreter.setTestEnvironment()
 
   test("Testing a lot of assignments") {
-    val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic0.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic0.oberon").toURI)
 
     assert(path != null)
 
@@ -50,7 +50,7 @@ class NewTypesTest extends AnyFunSuite{
   }
 
   test("Testing LONG and SHORT operations") {
-    val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic1.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic1.oberon").toURI)
 
     assert(path != null)
 
@@ -64,7 +64,7 @@ class NewTypesTest extends AnyFunSuite{
   }
 
   test("Testing LONGREAL and REAL +") {
-    val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic2.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic2.oberon").toURI)
 
     assert(path != null)
 

--- a/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
@@ -11,7 +11,7 @@ class ParserTestSuite extends AnyFunSuite {
   test("Testing the oberon simple01 code") {
     val module = ScalaParser.parseResource("simple/simple01.oberon")
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule1")
     assert(module.constants.size == 1)
     assert(module.constants.head == Constant("x", IntValue(5)))
   }
@@ -19,7 +19,7 @@ class ParserTestSuite extends AnyFunSuite {
   test("Testing the oberon simple02 code. This module has one constants and two variables") {
     val module = ScalaParser.parseResource("simple/simple02.oberon")
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule2")
     assert(module.constants.size == 1)
     assert(module.constants.head == Constant("x", IntValue(5)))
     assert(module.variables.size == 2)
@@ -30,7 +30,7 @@ class ParserTestSuite extends AnyFunSuite {
   test("Testing the oberon simple03 code. This module has three constants and two variables") {
     val module = ScalaParser.parseResource("simple/simple03.oberon")
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule3")
     assert(module.constants.size == 3)
     assert(module.constants.head == Constant("x", IntValue(5)))
     assert(module.constants(1) == Constant("y", IntValue(10)))
@@ -43,7 +43,7 @@ class ParserTestSuite extends AnyFunSuite {
 
   test("Testing the oberon simple04 code. This module has three constants, a sum, and two variables") {
     val module = ScalaParser.parseResource("simple/simple04.oberon")
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule4")
     assert(module.constants.size == 3)
     assert(module.constants.head == Constant("x", IntValue(5)))
     assert(module.constants(1) == Constant("y", IntValue(10)))
@@ -58,7 +58,7 @@ class ParserTestSuite extends AnyFunSuite {
   test("Testing the oberon simple05 code. This module has one constant, a multiplication, and two variables") {
     val module = ScalaParser.parseResource("simple/simple05.oberon")
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule5")
     assert(module.constants.size == 1)
     assert(module.constants.head == Constant("z", MultExpression(IntValue(5), IntValue(10))))
 
@@ -72,7 +72,7 @@ class ParserTestSuite extends AnyFunSuite {
   test("Testing the oberon simple06 code. This module has one constants, complex expression, and two variables") {
     val module = ScalaParser.parseResource("simple/simple06.oberon")
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule6")
     assert(module.constants.size == 1)
     assert(module.constants.head == Constant("z", AddExpression(IntValue(5), MultExpression(IntValue(10), IntValue(3)))))
 
@@ -85,7 +85,7 @@ class ParserTestSuite extends AnyFunSuite {
   test("Testing the oberon simple07 code. This module has two constants, a complex expression, and two variables") {
     val module = ScalaParser.parseResource("simple/simple07.oberon")
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule7")
     assert(module.constants.size == 2)
     assert(module.constants.head == Constant("x", AddExpression(IntValue(5), MultExpression(IntValue(10), IntValue(3)))))
       assert(module.constants(1) == Constant("y",
@@ -102,7 +102,7 @@ class ParserTestSuite extends AnyFunSuite {
   test("Testing the oberon simple08 code. This module has three constants, a boolean expresson, and two variables") {
     val module = ScalaParser.parseResource("simple/simple08.oberon")
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule8")
     assert(module.constants.size == 3)
     assert(module.constants.head == Constant("x", BoolValue(false)))
     assert(module.constants(1) == Constant("y", BoolValue(true)))
@@ -112,7 +112,7 @@ class ParserTestSuite extends AnyFunSuite {
   test("Testing the oberon simple09 code. This module has one constant and an expression involving both 'and' and 'or'") {
     val module = ScalaParser.parseResource("simple/simple09.oberon")
 
-    assert(module.name == "SimpleModule")
+    assert(module.name == "SimpleModule9")
     assert(module.constants.size == 1)
     assert(module.constants.head == Constant("z", OrExpression(AndExpression(BoolValue(true), BoolValue(false)), BoolValue(false))))
   }
@@ -1859,7 +1859,7 @@ class ParserTestSuite extends AnyFunSuite {
   }
 
   test("Printing new types on console") {
-    val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic34.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic34.oberon").toURI)
 
     assert(path != null)
 
@@ -1878,7 +1878,7 @@ class ParserTestSuite extends AnyFunSuite {
   }
 
   ignore("Reading new types") {
-    val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic35.oberon").getFile)
+    val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic35.oberon").toURI)
 
     assert(path != null)
 


### PR DESCRIPTION
Conserta:

- Os erros relacionados a path no SO windows
- Os conflitos no arquivo output de alguns testes que usavam o nome do módulo oberon em questão, que era o o mesmo. Portanto, para resolver esse problema, cada módulo foi renomeado para um nome único.