### PR TITLE
Jvm grupo 3

### DIFF
--- a/src/main/scala/br/unb/cic/oberon/codegen/GenerateClassFromRecord.scala
+++ b/src/main/scala/br/unb/cic/oberon/codegen/GenerateClassFromRecord.scala
@@ -28,8 +28,7 @@ object GenerateClassFromRecord{
           case BooleanType => cw.visitField(ACC_PUBLIC, v.name, "Z", null, null).visitEnd()
           case CharacterType => cw.visitField(ACC_PUBLIC, v.name, "C", null, null).visitEnd()
           case StringType => cw.visitField(ACC_PUBLIC, v.name, "Ljava/lang/String;", null, null).visitEnd()
-          // checar linha abaixo e ver como resolver o tipo array ccom o grupo array
-          case ReferenceToUserDefinedType(_) => cw.visitField(ACC_PUBLIC, v.name, "L" + v.name + ";", null, null).visitEnd()
+          case ReferenceToUserDefinedType(_) => cw.visitField(ACC_PUBLIC, v.name, null, null, null).visitEnd()
           case UndefinedType => cw.visitField(ACC_PUBLIC, v.name, "Ljava/lang/Object;", null, null).visitEnd()
         }
       )

--- a/src/main/scala/br/unb/cic/oberon/codegen/GenerateClassFromRecord.scala
+++ b/src/main/scala/br/unb/cic/oberon/codegen/GenerateClassFromRecord.scala
@@ -1,0 +1,41 @@
+package br.unb.cic.oberon.codegen
+
+import br.unb.cic.oberon.interpreter._
+import br.unb.cic.oberon.ast._
+import org.objectweb.asm._
+import org.objectweb.asm.Opcodes._
+
+import java.io.PrintStream
+import java.util.Base64
+
+import br.unb.cic.oberon.parser.ScalaParser
+
+import java.io.FileOutputStream
+import java.nio.file.{Files, Paths}
+
+import java.io.File
+
+object GenerateClassFromRecord{
+  def generateCode(record: RecordType): (String, Array[Byte]) = {
+      val cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+
+      cw.visit(V1_5, ACC_PUBLIC, record.name, null, "java/lang/Object", null);
+      record.variables.foreach((v : VariableDeclaration) =>
+        v.variableType match {
+
+          case IntegerType =>  cw.visitField(ACC_PUBLIC, v.name, "I", null, null).visitEnd()
+          case RealType =>  cw.visitField(ACC_PUBLIC, v.name, "D", null, null).visitEnd()
+          case BooleanType => cw.visitField(ACC_PUBLIC, v.name, "Z", null, null).visitEnd()
+          case CharacterType => cw.visitField(ACC_PUBLIC, v.name, "C", null, null).visitEnd()
+          case StringType => cw.visitField(ACC_PUBLIC, v.name, "Ljava/lang/String;", null, null).visitEnd()
+          // checar linha abaixo e ver como resolver o tipo array ccom o grupo array
+          case ReferenceToUserDefinedType(_) => cw.visitField(ACC_PUBLIC, v.name, "L" + v.name + ";", null, null).visitEnd()
+          case UndefinedType => cw.visitField(ACC_PUBLIC, v.name, "Ljava/lang/Object;", null, null).visitEnd()
+        }
+      )
+      cw.visitEnd()
+
+      (record.name, cw.toByteArray)
+    }
+}
+

--- a/src/test/resources/records/record_dentro_de_record.oberon
+++ b/src/test/resources/records/record_dentro_de_record.oberon
@@ -1,0 +1,16 @@
+MODULE record_inside_record;
+
+TYPE
+
+    pessoa = RECORD
+        idade : INTEGER;
+        renda : INTEGER;
+        tem_gato : BOOLEAN;
+    END
+
+    familia = RECORD
+        Kleber : pessoa;
+        mora_junto : BOOLEAN;
+    END
+
+END record_inside_record.

--- a/src/test/resources/records/record_simples_1.oberon
+++ b/src/test/resources/records/record_simples_1.oberon
@@ -1,4 +1,4 @@
-MODULE simple_record;
+MODULE simple_record_1;
 
 TYPE
     pessoa = RECORD
@@ -13,4 +13,4 @@ VAR
     mateus : pessoa;
     matematica : notas;
 
-END simple_record.
+END simple_record_1.

--- a/src/test/resources/records/record_simples_1.oberon
+++ b/src/test/resources/records/record_simples_1.oberon
@@ -1,0 +1,16 @@
+MODULE simple_record;
+
+TYPE
+    pessoa = RECORD
+        idade : INTEGER;
+        renda : INTEGER;
+        tem_gato : BOOLEAN;
+    END
+
+    notas = ARRAY 9 OF REAL
+
+VAR
+    mateus : pessoa;
+    matematica : notas;
+
+END simple_record.

--- a/src/test/resources/records/record_simples_2.oberon
+++ b/src/test/resources/records/record_simples_2.oberon
@@ -1,0 +1,13 @@
+MODULE simple_record_2;
+
+TYPE
+    floresta = RECORD
+        nr_arvores : INTEGER;
+        foi_desmatada : BOOLEAN;
+        propriedade_privada : BOOLEAN;
+    END
+
+CONST
+    nr_florestas = 3;
+
+END simple_record_2.

--- a/src/test/scala/br/unb/cic/oberon/codegen/JVMCodeGenTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/codegen/JVMCodeGenTest.scala
@@ -347,16 +347,16 @@ class JVMCodeGenTest extends AnyFunSuite {
     assert(0 == v.numberOfBooleanConstants);
   }
 
-  test("Generate bytecode from records"){
+  test("Generate bytecode from record, teste 1"){
 
-    val path = Paths.get(getClass.getClassLoader.getResource("records/record_1_simples.oberon").toURI)
+    val path = Paths.get(getClass.getClassLoader.getResource("records/record_simples_1.oberon").toURI)
 
     assert(path != null)
 
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "simple_record")
+    assert(module.name == "simple_record_1")
     assert(module.variables.size == 2)
     assert(module.constants.size == 0)
     assert(module.userTypes.size == 2)
@@ -386,14 +386,81 @@ class JVMCodeGenTest extends AnyFunSuite {
 
     val v = new ClassVisitorTest(ASM4);
 
-    // record dentro de record
-    // fazer mais testes (checar differentes atributos)
-    // resolver target;out -> done
-
     cr.accept(v, 0);
 
     assert(3 == v.numberOfTotalFields);
     assert(2 == v.numberOfIntegerVariables);
+    assert(1 == v.numberOfBooleanVariables);
+
+  }
+  test("Generate bytecode from record, teste 2"){
+
+    val path = Paths.get(getClass.getClassLoader.getResource("records/record_simples_2.oberon").toURI)
+
+    assert(path != null)
+
+    val content = String.join("\n", Files.readAllLines(path))
+    val module = ScalaParser.parse(content)
+
+    assert(module.name == "simple_record_2")
+    assert(module.variables.size == 0)
+    assert(module.constants.size == 1)
+    assert(module.userTypes.size == 1)
+
+    val codeGen = GenerateClassFromRecord
+
+    var record_name_and_bytecode = codeGen.generateCode(module.userTypes.head.asInstanceOf[RecordType])
+
+    val bytecode = record_name_and_bytecode._2
+
+    val out = new FileOutputStream(createOutputFile(record_name_and_bytecode._1).toFile)
+
+    out.write(bytecode)
+
+    val cr = new ClassReader(bytecode);
+
+    val v = new ClassVisitorTest(ASM4);
+    
+    cr.accept(v, 0);
+
+    assert(3 == v.numberOfTotalFields);
+    assert(1 == v.numberOfIntegerVariables);
+    assert(2 == v.numberOfBooleanVariables);
+
+  }
+
+  ignore("Generate bytecode from record, teste 3"){
+
+    val path = Paths.get(getClass.getClassLoader.getResource("records/record_dentro_de_record.oberon").toURI)
+
+    assert(path != null)
+
+    val content = String.join("\n", Files.readAllLines(path))
+    val module = ScalaParser.parse(content)
+
+    assert(module.name == "record_inside_record")
+    assert(module.variables.size == 0)
+    assert(module.constants.size == 0)
+    assert(module.userTypes.size == 2)
+
+    val codeGen = GenerateClassFromRecord
+
+    var record_name_and_bytecode = codeGen.generateCode(module.userTypes(1).asInstanceOf[RecordType])
+
+    val bytecode = record_name_and_bytecode._2
+
+    val out = new FileOutputStream(createOutputFile(record_name_and_bytecode._1).toFile)
+
+    out.write(bytecode)
+
+    val cr = new ClassReader(bytecode);
+
+    val v = new ClassVisitorTest(ASM4);
+
+    cr.accept(v, 0);
+
+    assert(2 == v.numberOfTotalFields);
+    assert(0 == v.numberOfIntegerVariables);
     assert(1 == v.numberOfBooleanVariables);
 
   }

--- a/src/test/scala/br/unb/cic/oberon/codegen/JVMCodeGenTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/codegen/JVMCodeGenTest.scala
@@ -361,18 +361,7 @@ class JVMCodeGenTest extends AnyFunSuite {
     assert(module.constants.size == 0)
     assert(module.userTypes.size == 2)
 
-    val codeGen = GenerateClassFromRecord
-    // var recordClassString = new String;
-
-    // val record_name_and_bytecode
-    // usa pattern matching para obter um record 
-    //  (o único record do arquivo oberon, ou o último, caso tenha mais de um record)
-    // module.userTypes.foreach((userDefinedTypes : UserDefinedType) =>
-    //   userDefinedTypes match {
-    //     case r: RecordType => val record_name_and_bytecode = codeGen.generateCode(r);
-    //     case a: ArrayType => null;
-    //   }
-    // )
+    val codeGen = GenerateClassFromRecords
 
     var record_name_and_bytecode = codeGen.generateCode(module.userTypes.head.asInstanceOf[RecordType])
 

--- a/src/test/scala/br/unb/cic/oberon/codegen/JVMCodeGenTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/codegen/JVMCodeGenTest.scala
@@ -340,9 +340,9 @@ class JVMCodeGenTest extends AnyFunSuite {
 
     cr.accept(v, 0);
 
-    assert(2 == v.numberOfTotalFields);
+    assert(1 == v.numberOfTotalFields);
     assert(0 == v.numberOfIntegerConstants);
-    assert(0 == v.numberOfIntegerVariables);
+    assert(1 == v.numberOfIntegerVariables);
     assert(0 == v.numberOfBooleanVariables);
     assert(0 == v.numberOfBooleanConstants);
   }
@@ -361,7 +361,7 @@ class JVMCodeGenTest extends AnyFunSuite {
     assert(module.constants.size == 0)
     assert(module.userTypes.size == 2)
 
-    val codeGen = GenerateClassFromRecords
+    val codeGen = GenerateClassFromRecord
 
     var record_name_and_bytecode = codeGen.generateCode(module.userTypes.head.asInstanceOf[RecordType])
 


### PR DESCRIPTION
Implements:

-  bytecode generation (to jvm) from record types in oberon
- two brand new tests to assert bytecode generation from records is correct
- one non functional test (set to be ignored) to check if records inside records are being properly converted to bytecode (they are not, currently)
- fixes wrong path generation: the function used to separate directories was File.pathSeparator, instead of the correct one, File.separator ([see here](https://stackoverflow.com/questions/5971964/when-should-i-use-file-separator-and-when-file-pathseparator))