### PR TITLE
Fixed test case for WRITEFILE stdlib function - Group 2

### DIFF
--- a/src/test/resources/stdlib/WRITEFILETest.oberon
+++ b/src/test/resources/stdlib/WRITEFILETest.oberon
@@ -6,7 +6,7 @@ VAR
   z : STRING;
 
 BEGIN
-  x := "src/test/resources/stdlib/plainFile.txt";
+  x := "src/test/resources/stdlib/writtenByWRITEFILE.txt";
   y := "Lorem ipsum dolor sit amet, consectetur adipiscing elit.";
   z := WRITEFILE(x, y)
 END

--- a/src/test/scala/br/unb/cic/oberon/stdlib/StandardLibraryTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/stdlib/StandardLibraryTest.scala
@@ -5,6 +5,8 @@ import br.unb.cic.oberon.interpreter.Interpreter
 import br.unb.cic.oberon.parser.ScalaParser
 import org.scalatest.funsuite.AnyFunSuite
 
+import scala.io.Source
+
 class StandardLibraryTest extends AnyFunSuite {
 
   test("Test for the ABS function") {
@@ -122,7 +124,7 @@ class StandardLibraryTest extends AnyFunSuite {
 
   }
 
-  ignore("Test for the WRITEFILE function") {
+  test("Test for the WRITEFILE function") {
     val module = ScalaParser.parseResource("stdlib/WRITEFILETest.oberon")
 
     assert(module.name == "WRITEFILETest")
@@ -132,13 +134,21 @@ class StandardLibraryTest extends AnyFunSuite {
 
     module.accept(interpreter)
 
-    assert(interpreter.env.lookup("x") == Some(StringValue("src/test/resources/stdlib/plainFile.txt")))
+    val fileName = "writtenByWRITEFILE.txt"
+    val pathToWrite = if (System.getProperty("os.name").split(" ")(0).contains("Windows"))
+                          "src\\test\\resources\\stdlib\\"
+                      else
+                          "src/test/resources/stdlib/"
+
+    val toWriteFullPath = pathToWrite + fileName
+    assert(interpreter.env.lookup("x") == Some(StringValue(toWriteFullPath)))
     assert(interpreter.env.lookup("y") == Some(StringValue("Lorem ipsum dolor sit amet, consectetur adipiscing elit.")))
 
-    if (System.getProperty("os.name").split(" ")(0).contains("Windows"))
-      assert(interpreter.env.lookup("z") == Some(StringValue("src\\test\\resources\\stdlib\\plainFile.txt")))
-    else
-      assert(interpreter.env.lookup("z") == Some(StringValue("src/test/resources/stdlib/plainFile.txt")))
+    val bufferedSource = Source.fromFile(toWriteFullPath)
+    val fileContent = bufferedSource.getLines().mkString
+    bufferedSource.close
+
+    assert(interpreter.env.lookup("y") == Some(StringValue(fileContent)))
 
   }
 


### PR DESCRIPTION
### **This was the last test for stdlib.**

Changed ignore -> test;
Completely fixed test's logic.

WARNING: will break on Windows considering that, even tho I am adding support when mounting pathToWrite (line 138), the tested Oberon module (file stdlib/WRITEFILETest.oberon) has an already pre-defined path string. And so, this might require manual adapting of the Oberon module's code before running test (Windows-only).

Student: Davi Amaral (200016750)
Group: 7