### PR TITLE
Fix some parser test cases - Grupo 5

### DIFF
--- a/src/main/antlr4/Oberon.g4
+++ b/src/main/antlr4/Oberon.g4
@@ -86,8 +86,11 @@ statement
  : var = Id ':=' exp = expression                                                                                             #AssignmentStmt
  | des = designator ':=' exp = expression                                                                                     #EAssignmentStmt
  | stmt += statement (';' stmt += statement)+                                                                                 #SequenceStmt
+ | 'readLongReal'   '(' var = Id ')'                                                                                          #ReadLongRealStmt
  | 'readReal'       '(' var = Id ')'                                                                                          #ReadRealStmt
+ | 'readLongInt'    '(' var = Id ')'                                                                                          #ReadLongIntStmt
  | 'readInt'        '(' var = Id ')'                                                                                          #ReadIntStmt
+ | 'readShortInt'   '(' var = Id ')'                                                                                          #ReadShortIntStmt
  | 'readChar'   '(' var = Id ')'                                                                                              #ReadCharStmt
  | 'write' '(' expression ')'                                                                                                 #WriteStmt
  | name = Id '(' arguments? ')'                                                                                               #ProcedureCall

--- a/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
+++ b/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
@@ -476,14 +476,29 @@ class ParserVisitor {
       stmt = ReadCharStmt(varName)
     }
 
+    override def visitReadLongRealStmt(ctx: OberonParser.ReadLongRealStmtContext): Unit = {
+      val varName = ctx.`var`.getText
+      stmt = ReadLongRealStmt(varName)
+    }
+
     override def visitReadRealStmt(ctx: OberonParser.ReadRealStmtContext): Unit = {
       val varName = ctx.`var`.getText
       stmt = ReadRealStmt(varName)
     }
 
+    override def visitReadLongIntStmt(ctx: OberonParser.ReadLongIntStmtContext): Unit = {
+      val varName = ctx.`var`.getText
+      stmt = ReadLongIntStmt(varName)
+    }
+
     override def visitReadIntStmt(ctx: OberonParser.ReadIntStmtContext): Unit = {
       val varName = ctx.`var`.getText
       stmt = ReadIntStmt(varName)
+    }
+
+    override def visitReadShortIntStmt(ctx: OberonParser.ReadShortIntStmtContext): Unit = {
+      val varName = ctx.`var`.getText
+      stmt = ReadShortIntStmt(varName)
     }
 
     override def visitWriteStmt(ctx: OberonParser.WriteStmtContext): Unit = {

--- a/src/test/resources/simple/userTypeSimple07.oberon
+++ b/src/test/resources/simple/userTypeSimple07.oberon
@@ -11,11 +11,11 @@ PROCEDURE initialize_array(pogArray : simple) : simple;
     i := 0;
 
     REPEAT
-      pogArray[i] = i*5;
+      pogArray[i] := i*5;
       i := i + 1
-    UNTIL i < 10;
+    UNTIL i = 10;
 
     RETURN pogArray
-  END
+  END initialize_array
 
 END UserTypeModule.

--- a/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
@@ -1794,7 +1794,7 @@ class ParserTestSuite extends AnyFunSuite {
 
   }
 
-  ignore("Testing the oberon userTypeSimple07 code module. This module has a procedure using a user defined type"){
+  test("Testing the oberon userTypeSimple07 code module. This module has a procedure using a user defined type"){
     val module = ScalaParser.parseResource("simple/userTypeSimple07.oberon")
 
     assert(module.name == "UserTypeModule")
@@ -1888,7 +1888,7 @@ class ParserTestSuite extends AnyFunSuite {
     assert(stmts(9) == WriteStmt(VarExpression("z")))
   }
 
-  ignore("Reading new types") {
+  test("Reading new types") {
     val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic35.oberon").toURI)
 
     assert(path != null)


### PR DESCRIPTION
Change 2 tests from ignore to test (userTypeSimple07, aritmetic35):

* userTypeSimple07:
fixes the simple/userTypeSimple07.oberon logic and syntax.
* aritmetic35 ("Printing new types on console"):
adds readLongReal, readLongInt and readShortInt to ANTLR
adds the visitRead methods for those types in ScalaParser