### PR TITLE
Fix test of negative array length - Grupo 3

### DIFF
--- a/src/test/resources/simple/userTypeSimple04.oberon
+++ b/src/test/resources/simple/userTypeSimple04.oberon
@@ -6,7 +6,7 @@ TYPE
     java = RECORD
         size : INTEGER;
         variables : cplusplus;
-        Varinho : myType
+        Varinho : myType;
     END
 
     python = ARRAY -5 OF java // The compiler doesn't recognize negative values !!! // Now it works, this test is being ignored

--- a/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
@@ -1729,7 +1729,7 @@ class ParserTestSuite extends AnyFunSuite {
 
   }
 
-  ignore("Testing the oberon userTypeSimple04 code module. This module has an array and a record type declarations, with the array declaration using negative size (useful for typecheck tests)") {
+  test("Testing the oberon userTypeSimple04 code module. This module has an array and a record type declarations, with the array declaration using negative size (useful for typecheck tests)") {
     val module = ScalaParser.parseResource("simple/userTypeSimple04.oberon")
 
     assert(module.name == "UserTypeModule")
@@ -1743,7 +1743,7 @@ class ParserTestSuite extends AnyFunSuite {
 
     assert(module.userTypes(0).baseType == ArrayType(10, BooleanType))
     assert(module.userTypes(1).baseType == RecordType(listDeclaration))
-    assert(module.userTypes(2).baseType == ArrayType(5, ReferenceToUserDefinedType("java")))
+    assert(module.userTypes(2).baseType == ArrayType(-5, ReferenceToUserDefinedType("java")))
   }
 
   test("Testing the oberon userTypeSimple05 code module. This module has some user type declarations with a variables using theses types"){


### PR DESCRIPTION
Fix for the last ignored test of the parser.

This consists of fixing a syntax error in userTypeSimple04.oberon and changing the expected value for the array length in the test case.

This may be seen as a WIP as I'm not sure what should the behavior of the parser be when finding an array with negative length. I would guess that an error should be thrown but, as it was, the test case seemed to indicate that the negative sign should be ignored.