### PR TITLE
Refactor and Fix OberonCore Issues - Grupo 4

### DIFF
--- a/src/test/scala/br/unb/cic/oberon/transformations/CoreTransformerTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/transformations/CoreTransformerTest.scala
@@ -217,6 +217,27 @@ class CoreTransformerTest extends AnyFunSuite {
     assert(stmts(3) == WriteStmt(VarExpression("sum")))
   }
 
+  test("Testing the RepeatUntilStmt02 evaluation after conversion to OberonCore") {
+    val path = Paths.get(getClass.getClassLoader.getResource("stmts/RepeatUntilStmt02.oberon").toURI)
+
+    assert(path != null)
+
+    val content = String.join("\n", Files.readAllLines(path))
+    val module = ScalaParser.parseResource("stmts/RepeatUntilStmt02.oberon")
+    val interpreter = new Interpreter()
+    val coreVisitor = new CoreVisitor()
+
+    val coreModule = coreVisitor.transformModule(module)
+
+    interpreter.setTestEnvironment()
+    coreModule.accept(interpreter)
+
+    assert(coreModule.name == "RepeatUntilModule")
+    assert(interpreter.env.lookup("sum") == Some(IntValue(330)));
+    assert(interpreter.env.lookup("x") == Some(IntValue(21)));
+
+  }
+
   // TODO
   test("Testing the RepeatUntilStmt06 evaluation after conversion to OberonCore") {
     val path = Paths.get(getClass.getClassLoader.getResource("stmts/RepeatUntilStmt06.oberon").toURI)
@@ -611,6 +632,25 @@ class CoreTransformerTest extends AnyFunSuite {
     assert((stmts(2) == WriteStmt(VarExpression("y"))))
   }
 
+  test("Testing the IfElseIfStmt02 evaluation after conversion to OberonCore") {
+    val path = Paths.get(getClass.getClassLoader.getResource("stmts/IfElseIfStmt02.oberon").toURI)
+
+    assert(path != null)
+
+    val content = String.join("\n", Files.readAllLines(path))
+    val module = ScalaParser.parse(content)
+    val interpreter = new Interpreter()
+    val coreVisitor = new CoreVisitor()
+
+    val coreModule = coreVisitor.transformModule(module)
+
+    interpreter.setTestEnvironment()
+    coreModule.accept(interpreter)
+
+    assert(module.name == "SimpleModule")
+
+    assert(interpreter.env.lookup("y") == Some(IntValue(2)));
+  }
 
   test("Testing the IfElseIfStmt03 evaluation after conversion to OberonCore") {
     val path = Paths.get(getClass.getClassLoader.getResource("stmts/IfElseIfStmt03.oberon").toURI)


### PR DESCRIPTION
## Changes
* Refactored CoreTransformer.scala to address the following issues:
  - CaseStmt with two or more cases and no trailing ELSE clause in the Oberon source code was not being converted correctly.
  - IfElseIf with no trailing ELSE clause in the Oberon source code was not converted correctly.
  - Removed comments pertaining to the old code that has been replaced.
* Added two new test cases to CoreTransformerTest.scala to ensure the previously fixed issues are covered from now on.

## Comment
While working on updating the interpreter module to support only OberonCore, I stumbled upon the aforementioned two issues. Since the original code was confusing and difficult to debug, I decided to rewrite it from scratch.

Student: Gabriel Santos Menezes (170050157)
Group: 4