### PR TITLE
Fixes/Adds functions for solving Beecrowd problems - Grupo 5

### DIFF
--- a/src/main/antlr4/Oberon.g4
+++ b/src/main/antlr4/Oberon.g4
@@ -86,8 +86,11 @@ statement
  : var = Id ':=' exp = expression                                                                                             #AssignmentStmt
  | des = designator ':=' exp = expression                                                                                     #EAssignmentStmt
  | stmt += statement (';' stmt += statement)+                                                                                 #SequenceStmt
+ | 'readLongReal'   '(' var = Id ')'                                                                                          #ReadLongRealStmt
  | 'readReal'       '(' var = Id ')'                                                                                          #ReadRealStmt
+ | 'readLongInt'    '(' var = Id ')'                                                                                          #ReadLongIntStmt
  | 'readInt'        '(' var = Id ')'                                                                                          #ReadIntStmt
+ | 'readShortInt'   '(' var = Id ')'                                                                                          #ReadShortIntStmt
  | 'readChar'   '(' var = Id ')'                                                                                              #ReadCharStmt
  | 'write' '(' expression ')'                                                                                                 #WriteStmt
  | name = Id '(' arguments? ')'                                                                                               #ProcedureCall

--- a/src/main/antlr4/Oberon.g4
+++ b/src/main/antlr4/Oberon.g4
@@ -72,9 +72,10 @@ expression
  | exp = expression '.' name = Id                                                         #FieldAccess
  | arrayBase = expression '[' index = expression ']'                                      #ArraySubscript
  | name = Id '^'                                                                          #PointerAccess
+ | '~' exp = expression                                                                   #NotExpression
  | left = expression opr = ('=' | '#' | '<' | '<=' | '>' | '>=')  right = expression      #RelExpression
  | left = expression opr = ('*' | '/' | '&&') right = expression                          #MultExpression
- | left = expression opr = ('+' | '-' | '||') right = expression                          #AddExpression
+ | left = expression opr = ('MOD' | '+' | '-' | '||') right = expression                  #AddExpression
  ;
 
 qualifiedName
@@ -92,6 +93,8 @@ statement
  | 'readInt'        '(' var = Id ')'                                                                                          #ReadIntStmt
  | 'readShortInt'   '(' var = Id ')'                                                                                          #ReadShortIntStmt
  | 'readChar'   '(' var = Id ')'                                                                                              #ReadCharStmt
+ | 'INC' '(' var = Id ')'                                                                                                     #IncStmt
+ | 'DEC' '(' var = Id ')'                                                                                                     #DecStmt
  | 'write' '(' expression ')'                                                                                                 #WriteStmt
  | name = Id '(' arguments? ')'                                                                                               #ProcedureCall
  | 'IF' cond = expression 'THEN' thenStmt = statement ('ELSE' elseStmt = statement)? 'END'                                    #IfElseStmt

--- a/src/main/scala/br/unb/cic/oberon/ast/OberonModule.scala
+++ b/src/main/scala/br/unb/cic/oberon/ast/OberonModule.scala
@@ -94,7 +94,12 @@ sealed trait Number extends Expression {
   def /(that: Number): Number
 
 }
-case class IntValue(value: Int) extends Value with Number{
+
+sealed trait Modular extends Number {
+  def mod(that: Modular): Modular
+}
+
+case class IntValue(value: Int) extends Value with Modular {
   type T = Int
   def +(that: Number): Number = that match {
     case other: IntValue => IntValue(value + other.value)
@@ -116,6 +121,11 @@ case class IntValue(value: Int) extends Value with Number{
     case other: RealValue => RealValue(value / other.value)
   }
 
+  val positiveMod = (x: Int, y:Int) => {val res = x % y; if (x < 0) res + y else res}
+
+  def mod(that: Modular): Modular = that match{
+    case other: IntValue => IntValue(positiveMod(value, other.value))
+  }
 }
 
 case class RealValue(value: Double) extends Value with Number {
@@ -168,6 +178,8 @@ case class MultExpression(left: Expression, right: Expression) extends Expressio
 case class DivExpression(left: Expression, right: Expression) extends Expression
 case class OrExpression(left: Expression, right: Expression) extends Expression
 case class AndExpression(left: Expression, right: Expression) extends Expression
+case class ModExpression(left: Expression, right: Expression) extends Expression
+case class NotExpression(exp: Expression) extends Expression
 
 /* Statements */
 trait Statement {
@@ -183,6 +195,8 @@ case class ReadLongIntStmt(varName: String) extends Statement
 case class ReadIntStmt(varName: String) extends Statement
 case class ReadShortIntStmt(varName: String) extends Statement
 case class ReadCharStmt(varName: String) extends Statement
+case class IncStmt(varName: String) extends Statement
+case class DecStmt(varName: String) extends Statement
 case class WriteStmt(expression: Expression) extends Statement
 case class ProcedureCallStmt(name: String, args: List[Expression]) extends Statement
 case class IfElseStmt(condition: Expression, thenStmt: Statement, elseStmt: Option[Statement]) extends Statement

--- a/src/main/scala/br/unb/cic/oberon/cfg/ControlFlowGraphBuilder.scala
+++ b/src/main/scala/br/unb/cic/oberon/cfg/ControlFlowGraphBuilder.scala
@@ -33,8 +33,20 @@ class IntraProceduralGraphBuilder extends ControlFlowGraphBuilder {
 
     stmt match {
       case SequenceStmt(stmts) =>
-        g += StartNode() ~> SimpleNode(stmts.head)
+        stmts.head match {
+          case ForStmt(init,_ ,_ ) =>
+            g += StartNode() ~> SimpleNode(init)
+          case _ =>
+            g += StartNode() ~> SimpleNode(stmts.head)
+        }
         createControlFlowGraph(stmts, g)
+
+      case ForStmt(init, _ , forStmt) =>
+        g += StartNode() ~> SimpleNode(init)
+        g += SimpleNode(init) ~> SimpleNode(stmt)
+        g += SimpleNode(stmt) ~> EndNode()
+        processStmtNode(stmt, Some(forStmt), g)
+
       case _ =>
         g += StartNode() ~> SimpleNode(stmt)
         g += SimpleNode(stmt) ~> EndNode()
@@ -47,28 +59,62 @@ class IntraProceduralGraphBuilder extends ControlFlowGraphBuilder {
    * @param g a graph used as accumulator
    * @return a new version of the graph
    */
-  def createControlFlowGraph(stmts: List[Statement], g: Graph[GraphNode, GraphEdge.DiEdge]): Graph[GraphNode, GraphEdge.DiEdge] =
- stmts match {
+  def createControlFlowGraph(stmts: List[Statement], g: Graph[GraphNode, GraphEdge.DiEdge]): Graph[GraphNode, GraphEdge.DiEdge] = {
+    stmts match {
     case s1 :: s2 :: rest => // case the list has at least two elements. this is the recursive case
       s1 match {
         case IfElseStmt(_, _, Some(_)) => // in this case, we do not create an edge from s1 -> s2
-          processStmtNode(s1, Some(s2), g)
+          s2 match {
+            case ForStmt(init,_ ,_) =>
+              processStmtNode(s1, Some(init), g)
+            case _ =>
+              processStmtNode(s1, Some(s2), g)
+          }
           createControlFlowGraph(s2 :: rest, g)
         case CaseStmt(_, _, Some(_)) =>
-          processStmtNode(s1, Some(s2), g)
+          s2 match {
+            case ForStmt(init,_ ,_) =>
+              processStmtNode(s1, Some(init), g)
+            case _ =>
+              processStmtNode(s1, Some(s2), g)
+          }
           createControlFlowGraph(s2 :: rest, g)
         case IfElseIfStmt(_, _, _, Some(_)) =>
-          processStmtNode(s1, Some(s2), g)
+          s2 match {
+            case ForStmt(init,_ ,_) =>
+              processStmtNode(s1, Some(init), g)
+            case _ =>
+              processStmtNode(s1, Some(s2), g)
+          }
+          createControlFlowGraph(s2 :: rest, g)
+        case ForStmt(init, _ , forStmt) =>
+          g += SimpleNode(init) ~> SimpleNode(s1)
+          g += SimpleNode(s1) ~> SimpleNode(s2)
+          processStmtNode(s1, Some(forStmt), g)
           createControlFlowGraph(s2 :: rest, g)
         case _ =>
-          g += SimpleNode(s1) ~> SimpleNode(s2)
-          processStmtNode(s1, Some(s2), g)
+          s2 match {
+            case ForStmt(init,_ , _) =>
+              g += SimpleNode(s1) ~> SimpleNode(init)
+            case _ =>
+              g += SimpleNode(s1) ~> SimpleNode(s2)
+              processStmtNode(s1, Some(s2), g)
+          }
           createControlFlowGraph(s2 :: rest, g)
       }
     case s1 :: List() => // case the list has just one element. this is the base case
+      s1 match {
+        case ForStmt(init, _ , forStmt) =>
+          g += SimpleNode(init) ~> SimpleNode(s1)
+          processStmtNode(s1, Some(forStmt), g)
+        case _ =>
+
+      }
+
       g += SimpleNode(s1) ~> EndNode()
       processStmtNode(s1, None, g) // process the singleton node of the stmts list of statements
       g
+  }
   }
 
 
@@ -88,11 +134,11 @@ class IntraProceduralGraphBuilder extends ControlFlowGraphBuilder {
         }
         g // returns g
       case WhileStmt(_, whileStmt) =>
-        processStmtNode(from, whileStmt, target, g) // returns the recursive call
+        processStmtNode(from, whileStmt, Some(from), g) // returns the recursive call
       case RepeatUntilStmt(_, repeatUntilStmt) =>
         processStmtNode(from, repeatUntilStmt, target, g) // returns the recursive call
-      case ForStmt(init,_ ,forStmt) =>
-        processStmtNode(init, forStmt, target, g)
+      case ForStmt(_,_ ,forStmt) =>
+        processStmtNode(from, forStmt, Some(from), g)
       case IfElseIfStmt(_, thenStmt, elseIfStmt, optionalElseStmt) =>
         processStmtNode(from, thenStmt, target, g)
           elseIfStmt.foreach((ifElseIfBlock) => {

--- a/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
+++ b/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
@@ -476,14 +476,29 @@ class ParserVisitor {
       stmt = ReadCharStmt(varName)
     }
 
+    override def visitReadLongRealStmt(ctx: OberonParser.ReadLongRealStmtContext): Unit = {
+      val varName = ctx.`var`.getText
+      stmt = ReadLongRealStmt(varName)
+    }
+
     override def visitReadRealStmt(ctx: OberonParser.ReadRealStmtContext): Unit = {
       val varName = ctx.`var`.getText
       stmt = ReadRealStmt(varName)
     }
 
+    override def visitReadLongIntStmt(ctx: OberonParser.ReadLongIntStmtContext): Unit = {
+      val varName = ctx.`var`.getText
+      stmt = ReadLongIntStmt(varName)
+    }
+
     override def visitReadIntStmt(ctx: OberonParser.ReadIntStmtContext): Unit = {
       val varName = ctx.`var`.getText
       stmt = ReadIntStmt(varName)
+    }
+
+    override def visitReadShortIntStmt(ctx: OberonParser.ReadShortIntStmtContext): Unit = {
+      val varName = ctx.`var`.getText
+      stmt = ReadShortIntStmt(varName)
     }
 
     override def visitWriteStmt(ctx: OberonParser.WriteStmtContext): Unit = {

--- a/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
+++ b/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
@@ -403,6 +403,11 @@ class ParserVisitor {
       exp = FunctionCallExpression(name, args.toList)
     }
 
+    override def visitNotExpression(ctx: OberonParser.NotExpressionContext): Unit = {
+      ctx.exp.accept(this)
+      exp = NotExpression(exp)
+    }
+
     private def expression(opr: String): (Expression, Expression) => Expression =
       opr match {
         case "=" => EQExpression
@@ -417,6 +422,7 @@ class ParserVisitor {
         case "/" => DivExpression
         case "&&" => AndExpression
         case "||" => OrExpression
+        case "MOD" => ModExpression
       }
 
     /*
@@ -505,6 +511,16 @@ class ParserVisitor {
       val visitor = new ExpressionVisitor()
       ctx.expression().accept(visitor)
       stmt = WriteStmt(visitor.exp)
+    }
+
+    override def visitIncStmt(ctx: OberonParser.IncStmtContext): Unit = {
+      val varName = ctx.`var`.getText
+      stmt = IncStmt(varName)
+    }
+
+    override def visitDecStmt(ctx: OberonParser.DecStmtContext): Unit = {
+      val varName = ctx.`var`.getText
+      stmt = DecStmt(varName)
     }
 
     override def visitProcedureCall(ctx: OberonParser.ProcedureCallContext): Unit = {

--- a/src/main/scala/br/unb/cic/oberon/stdlib/StandardLibrary.scala
+++ b/src/main/scala/br/unb/cic/oberon/stdlib/StandardLibrary.scala
@@ -21,7 +21,8 @@ class StandardLibrary[T](env: Environment[T]) {
     string
   }
 
-  val stdlib = OberonModule("STDLIB", Set.empty[String], List(), List(), List(), List(abs, odd, floor, round, power, sqrroot, ceil, readFile, writeFile, appendFile), None)
+  val stdlib = OberonModule("STDLIB", Set.empty[String], List(), List(), List(),
+    List(abs, odd, ceil, floor, round, intToFloat, power, sqrroot, ceil, readFile, writeFile, appendFile), None)
 
   def abs = Procedure(
     "ABS",                             // name
@@ -55,35 +56,46 @@ class StandardLibrary[T](env: Environment[T]) {
   def ceil = Procedure(
     "CEIL",                         // name
     List(ParameterByValue("x", RealType)), // formal arguments
-    Some(RealType),                 // return type
+    Some(IntegerType),                 // return type
     List(),                         // local constants
     List(),                         // local variables
 
     SequenceStmt(
-      List(MetaStmt(() => ReturnStmt(RealValue(env.lookup("x").get.asInstanceOf[RealValue].value.ceil))))
+      List(MetaStmt(() => ReturnStmt(IntValue(env.lookup("x").get.asInstanceOf[RealValue].value.ceil.toInt))))
     )
   )
 
   def floor = Procedure(
-    "FLR",
+    "FLOOR",
     List(ParameterByValue("x", RealType)),
-    Some(RealType),
+    Some(IntegerType),
     List(),
     List(),
 
     SequenceStmt(
-      List(MetaStmt(() => ReturnStmt(RealValue(env.lookup(name = "x").get.asInstanceOf[RealValue].value.floor)))))
+      List(MetaStmt(() => ReturnStmt(IntValue(env.lookup(name = "x").get.asInstanceOf[RealValue].value.floor.toInt)))))
   )
 
   def round = Procedure(
     "RND",
     List(ParameterByValue("x", RealType)),
+    Some(IntegerType),
+    List(),
+    List(),
+
+    SequenceStmt(
+      List(MetaStmt(() => ReturnStmt(IntValue(env.lookup(name = "x").get.asInstanceOf[RealValue].value.round.toInt)))))
+  )
+
+  def intToFloat = Procedure(
+    "FLT",
+    List(ParameterByValue("x", IntegerType)),
     Some(RealType),
     List(),
     List(),
 
     SequenceStmt(
-      List(MetaStmt(() => ReturnStmt(RealValue(env.lookup(name = "x").get.asInstanceOf[RealValue].value.round)))))
+      List(MetaStmt(() => ReturnStmt(RealValue(env.lookup(name = "x").get.asInstanceOf[IntValue].value.toFloat)))))
   )
   def power = Procedure(
     "POW",

--- a/src/test/resources/aritmetic/aritmetic37.oberon
+++ b/src/test/resources/aritmetic/aritmetic37.oberon
@@ -1,0 +1,17 @@
+MODULE Aritmetic37;
+
+VAR
+  x : INTEGER;
+  y : INTEGER;
+  z : INTEGER;
+  w : INTEGER;
+
+BEGIN
+  x := 5;
+  y := 3;
+  z := x MOD y;
+  w := (-1)* x MOD y
+END
+
+
+END Aritmetic37.

--- a/src/test/resources/boolean/boolean32.oberon
+++ b/src/test/resources/boolean/boolean32.oberon
@@ -1,0 +1,16 @@
+MODULE Boolean32;
+
+VAR
+  x : BOOLEAN;
+  a : BOOLEAN;
+  b : BOOLEAN;
+
+
+BEGIN
+    x := True;
+    a := ~x;
+    b := ~a
+
+END
+
+END Boolean32.

--- a/src/test/resources/simple/userTypeSimple07.oberon
+++ b/src/test/resources/simple/userTypeSimple07.oberon
@@ -11,11 +11,11 @@ PROCEDURE initialize_array(pogArray : simple) : simple;
     i := 0;
 
     REPEAT
-      pogArray[i] = i*5;
+      pogArray[i] := i*5;
       i := i + 1
-    UNTIL i < 10;
+    UNTIL i = 10;
 
     RETURN pogArray
-  END
+  END initialize_array
 
 END UserTypeModule.

--- a/src/test/resources/stdlib/CEILTest.oberon
+++ b/src/test/resources/stdlib/CEILTest.oberon
@@ -3,8 +3,8 @@ MODULE CEILTest;
 VAR
     x : REAL;
     y : REAL;
-    z : REAL;
-    w : REAL;
+    z : INTEGER;
+    w : INTEGER;
 
 BEGIN
     x := 10.0;

--- a/src/test/resources/stdlib/FLRTest.oberon
+++ b/src/test/resources/stdlib/FLRTest.oberon
@@ -1,15 +1,15 @@
-MODULE FLRTest;
+MODULE FLOORTest;
 
 VAR
   x : REAL;
   y : REAL;
-  z : REAL;
-  w : REAL;
+  z : INTEGER;
+  w : INTEGER;
 
 BEGIN
   w := 50.1;
   x := 10.8;
-  y := FLR(x);
-  z := FLR(w)
+  y := FLOOR(x);
+  z := FLOOR(w)
 END
 END FLRTest.

--- a/src/test/resources/stdlib/FLTTest.oberon
+++ b/src/test/resources/stdlib/FLTTest.oberon
@@ -1,0 +1,15 @@
+MODULE FLTTest;
+
+VAR
+  x : INTEGER;
+  y : REAL;
+  z : REAL;
+  w : INTEGER;
+
+BEGIN
+  w := 2;
+  x := -8;
+  y := FLT(x);
+  z := FLT(w)
+END
+END FLTTest.

--- a/src/test/resources/stdlib/RNDTest.oberon
+++ b/src/test/resources/stdlib/RNDTest.oberon
@@ -2,8 +2,8 @@ MODULE RNDTest;
 
 VAR
   x : REAL;
-  y : REAL;
-  z : REAL;
+  y : INTEGER;
+  z : INTEGER;
   w : REAL;
 
 BEGIN

--- a/src/test/resources/stmts/ArrayAssignmentStmt03.oberon
+++ b/src/test/resources/stmts/ArrayAssignmentStmt03.oberon
@@ -1,4 +1,8 @@
-MODULE SimpleModule;
+MODULE ArrayAssignmentStmt03;
+
+VAR
+  array : ARRAY 3 OF INTEGER;
+  outroarray : ARRAY 2 OF INTEGER;
 
 BEGIN
  array[0] := 10;
@@ -8,4 +12,4 @@ BEGIN
  outroarray[1] := 5
 END
 
-END SimpleModule.
+END ArrayAssignmentStmt03.

--- a/src/test/resources/stmts/DECTest.oberon
+++ b/src/test/resources/stmts/DECTest.oberon
@@ -1,0 +1,13 @@
+MODULE DECTest;
+
+VAR
+  x : INTEGER;
+  y : REAL;
+
+BEGIN
+    x := 9;
+    y := -8.0;
+    DEC(x);
+    DEC(y)
+END
+END DECTest.

--- a/src/test/resources/stmts/INCTest.oberon
+++ b/src/test/resources/stmts/INCTest.oberon
@@ -1,0 +1,13 @@
+MODULE INCTest;
+
+VAR
+  x : REAL;
+  y : INTEGER;
+
+BEGIN
+    x := 9.0;
+    y := -8;
+    INC(x);
+    INC(y)
+END
+END INCTest.

--- a/src/test/scala/br/unb/cic/oberon/graph/ControlFlowGraphTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/graph/ControlFlowGraphTest.scala
@@ -100,7 +100,7 @@ test("Test control flow graph for stmt01.oberon") {
     assert(expected == g)
   }
   /** Whilestmt test */
-  ignore("Test control flow graph for stmt04.oberon") {
+  test("Test control flow graph for stmt04.oberon") {
     val s3_1 = AssignmentStmt("x", MultExpression(VarExpression("x"), VarExpression("x")))
     val s1 = ReadIntStmt("x")
     val s2 = ReadIntStmt("y")
@@ -256,7 +256,7 @@ test("Test control flow graph for stmt01.oberon") {
     assert(expected == g)  // does the resulting control-flow graph match with the expected graph?
   }
 
-  ignore("Test control flow graph for stmt13.oberon") {
+  test("Test control flow graph for stmt13.oberon") {
 
 
     /**
@@ -300,7 +300,7 @@ test("Test control flow graph for stmt01.oberon") {
     val g = builder.createControlFlowGraph(SequenceStmt(stmts))
 
     assert( 7 == g.nodes.size)
-    assert( 6 == g.edges.size)
+    assert( 7 == g.edges.size)
 
     assert(expected == g)  // does the resulting control-flow graph match with the expected graph?
   }

--- a/src/test/scala/br/unb/cic/oberon/graph/ControlFlowGraphTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/graph/ControlFlowGraphTest.scala
@@ -130,7 +130,7 @@ test("Test control flow graph for stmt01.oberon") {
     assert(expected == g)  // does the resulting control-flow graph match with the expected graph?
   }
   /**Forstmt Test*/
-  ignore("Test control flow graph for stmt11.oberon") {
+  test("Test control flow graph for stmt11.oberon") {
 
 
     /**
@@ -145,26 +145,28 @@ test("Test control flow graph for stmt01.oberon") {
      *
      */
 
-    val s3_1 = ReadIntStmt("z")
     val s1 = ReadIntStmt("x")
-    val s2 = AssignmentStmt("y", IntValue(0))
-    val s3 = ForStmt(s2, LTExpression(VarExpression("y"), VarExpression("x")), s3_1)
-    val s4 = AssignmentStmt("z", DivExpression(VarExpression("z"), AddExpression(VarExpression("y"), IntValue(1))))
-    val s5 = WriteStmt(VarExpression("z"))
+
+    val s2_0 = AssignmentStmt("y", IntValue(0))
+    val s2_1 = ReadIntStmt("z")
+    val s2_2 = AssignmentStmt("z", DivExpression(VarExpression("z"), AddExpression(VarExpression("y"), IntValue(1))))
+    val s2_3 = WriteStmt(VarExpression("z"))
+    val s2 = ForStmt(s2_0, LTExpression(VarExpression("y"), VarExpression("x")), SequenceStmt(List(s2_1, s2_2, s2_3)))
 
 
     // we manually build the "expected" graph, to run the test case.
     var expected = Graph[GraphNode, GraphEdge.DiEdge]() //Expected: 7 nodes
 
     expected += StartNode() ~> SimpleNode(s1)
-    expected += SimpleNode(s1) ~> SimpleNode(s2)
-    expected += SimpleNode(s2) ~> SimpleNode(s3)
-    expected += SimpleNode(s3) ~> SimpleNode(s3_1)
-    expected += SimpleNode(s3_1) ~> SimpleNode(s4)
-    expected += SimpleNode(s4) ~> SimpleNode(s5)
-    expected += SimpleNode(s5) ~> EndNode()
+    expected += SimpleNode(s1) ~> SimpleNode(s2_0)
+    expected += SimpleNode(s2_0) ~> SimpleNode(s2)
+    expected += SimpleNode(s2) ~> SimpleNode(s2_1)
+    expected += SimpleNode(s2_1) ~> SimpleNode(s2_2)
+    expected += SimpleNode(s2_2) ~> SimpleNode(s2_3)
+    expected += SimpleNode(s2_3) ~> SimpleNode(s2)
+    expected += SimpleNode(s2) ~> EndNode()
 
-    val stmts = List(s1, s2, s3, s4, s5)
+    val stmts = List(s1, s2)
 
     val builder = new IntraProceduralGraphBuilder()
     val g = builder.createControlFlowGraph(SequenceStmt(stmts))
@@ -175,7 +177,7 @@ test("Test control flow graph for stmt01.oberon") {
     assert(expected == g)  // does the resulting control-flow graph match with the expected graph?
   }
 
-  ignore("Test control flow graph for stmt12.oberon") {
+  test("Test control flow graph for stmt12.oberon") {
 
 
     /**
@@ -208,14 +210,14 @@ test("Test control flow graph for stmt01.oberon") {
     val s3_0 = AssignmentStmt("y", IntValue(0))
     val s3_1 = ReadIntStmt("w")
     val s3_2 = AssignmentStmt("v", AddExpression(VarExpression("v"), MultExpression(VarExpression("w"), AddExpression(VarExpression("y"), IntValue(1)))))
-    val s3 = ForStmt(s3_0, LTExpression(VarExpression("y"), VarExpression("x")), s3_1)
+    val s3 = ForStmt(s3_0, LTExpression(VarExpression("y"), VarExpression("x")), SequenceStmt(List(s3_1,s3_2)))
 
     val s4 = AssignmentStmt("v", DivExpression(VarExpression("v"), VarExpression("x")))
 
     val s5_0 = AssignmentStmt("z", IntValue(0))
     val s5_1 = ReadIntStmt("w")
     val s5_2 = AssignmentStmt("u", AddExpression(VarExpression("u"), VarExpression("w")))
-    val s5 = ForStmt(s5_0, LTExpression(VarExpression("z"), VarExpression("x")), s5_1)
+    val s5 = ForStmt(s5_0, LTExpression(VarExpression("z"), VarExpression("x")), SequenceStmt(List(s5_1, s5_2)))
 
 
     val s6 = AssignmentStmt("u", DivExpression(VarExpression("u"), VarExpression("x")))
@@ -228,13 +230,15 @@ test("Test control flow graph for stmt01.oberon") {
 
     expected += StartNode() ~> SimpleNode(s1)
     expected += SimpleNode(s1) ~> SimpleNode(s2)
-    expected += SimpleNode(s2) ~> SimpleNode(s3)
+    expected += SimpleNode(s2) ~> SimpleNode(s3_0)
+    expected += SimpleNode(s3_0) ~> SimpleNode(s3)
     expected += SimpleNode(s3) ~> SimpleNode(s3_1)
     expected += SimpleNode(s3_1) ~> SimpleNode(s3_2)
     expected += SimpleNode(s3_2) ~> SimpleNode(s3)
     expected += SimpleNode(s3) ~> SimpleNode(s4)
 
-    expected += SimpleNode(s4) ~> SimpleNode(s5)
+    expected += SimpleNode(s4) ~> SimpleNode(s5_0)
+    expected += SimpleNode(s5_0) ~> SimpleNode(s5)
     expected += SimpleNode(s5) ~> SimpleNode(s5_1)
     expected += SimpleNode(s5_1) ~> SimpleNode(s5_2)
     expected += SimpleNode(s5_2) ~> SimpleNode(s5)
@@ -245,14 +249,13 @@ test("Test control flow graph for stmt01.oberon") {
 
     expected += SimpleNode(s8) ~> EndNode()
 
-    val stmts = List(s1, s2, s3, s3_2, s4, s5, s5_2, s6, s7, s8)
+    val stmts = List(s1, s2, s3 , s4, s5, s6, s7, s8)
 
     val builder = new IntraProceduralGraphBuilder()
     val g = builder.createControlFlowGraph(SequenceStmt(stmts))
 
     assert( 15 == g.nodes.size)
-    assert( 15 == g.edges.size)
-
+    assert( 17 == g.edges.size)
     assert(expected == g)  // does the resulting control-flow graph match with the expected graph?
   }
 

--- a/src/test/scala/br/unb/cic/oberon/interpreter/InterpreterTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/interpreter/InterpreterTest.scala
@@ -481,4 +481,69 @@ class InterpreterTest extends AnyFunSuite {
     assert(interpreter.env.lookup("x") == Some(IntValue(1)))
     //assert(interpreter.env.lookup("x") == Some(IntValue(2)))
   }
+
+  ignore("Testing ArrayAssignmentStmt03"){
+    val module = ScalaParser.parseResource("stmts/ArrayAssignmentStmt03.oberon")
+
+    assert(module.name == "ArrayAssignmentStmt03")
+    module.accept(interpreter)
+    assert(interpreter.env.lookup("array").isDefined)
+    assert(interpreter.env.lookup("outroarray").isDefined)
+
+
+    assert(interpreter.env.lookupArrayIndex("outoarray", 0) == Some(IntValue(1)))
+    assert(interpreter.env.lookupArrayIndex("outoarray", 1) == Some(IntValue(5)))
+
+    for (i <- 0 to 2){
+      assert(interpreter.env.lookupArrayIndex("array", i) == Some(IntValue(10*(i+1))))
+    }
+  }
+
+  test("Testing aritmetic37"){
+    val module = ScalaParser.parseResource("aritmetic/aritmetic37.oberon")
+
+    assert(module.name == "Aritmetic37")
+    module.accept(interpreter)
+
+    assert(interpreter.env.lookup("x") == Some(IntValue(5)))
+    assert(interpreter.env.lookup("y") == Some(IntValue(3)))
+    assert(interpreter.env.lookup("z") == Some(IntValue(2)))
+    assert(interpreter.env.lookup("w") == Some(IntValue(1)))
+
+  }
+
+  test(testName = "Test for the INC function"){
+    val module = ScalaParser.parseResource("stmts/INCTest.oberon")
+
+    assert(module.name == "INCTest")
+
+    module.accept(interpreter)
+
+    assert(interpreter.env.lookup("x") == Some(RealValue(10.0)))
+    assert(interpreter.env.lookup("y") == Some(IntValue(-7)))
+
+  }
+
+  test(testName = "Test for the DEC function"){
+    val module = ScalaParser.parseResource("stmts/DECTest.oberon")
+
+    assert(module.name == "DECTest")
+
+    module.accept(interpreter)
+
+    assert(interpreter.env.lookup("x") == Some(IntValue(8)))
+    assert(interpreter.env.lookup("y") == Some(RealValue(-9.0)))
+  }
+
+  test(testName = "Testing boolean32"){
+    val module = ScalaParser.parseResource("boolean/boolean32.oberon")
+
+    assert(module.name == "Boolean32")
+
+    module.accept(interpreter)
+
+    assert(interpreter.env.lookup("x") == Some(BoolValue(true)))
+    assert(interpreter.env.lookup("a") == Some(BoolValue(false)))
+    assert(interpreter.env.lookup("b") == Some(BoolValue(true)))
+  }
 }

--- a/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
@@ -1794,7 +1794,7 @@ class ParserTestSuite extends AnyFunSuite {
 
   }
 
-  ignore("Testing the oberon userTypeSimple07 code module. This module has a procedure using a user defined type"){
+  test("Testing the oberon userTypeSimple07 code module. This module has a procedure using a user defined type"){
     val module = ScalaParser.parseResource("simple/userTypeSimple07.oberon")
 
     assert(module.name == "UserTypeModule")
@@ -1888,7 +1888,7 @@ class ParserTestSuite extends AnyFunSuite {
     assert(stmts(9) == WriteStmt(VarExpression("z")))
   }
 
-  ignore("Reading new types") {
+  test("Reading new types") {
     val path = Paths.get(getClass.getClassLoader.getResource("aritmetic/aritmetic35.oberon").toURI)
 
     assert(path != null)

--- a/src/test/scala/br/unb/cic/oberon/stdlib/StandardLibraryTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/stdlib/StandardLibraryTest.scala
@@ -37,18 +37,18 @@ class StandardLibraryTest extends AnyFunSuite {
     assert(interpreter.env.lookup("w") == Some(BoolValue(true)))
   }
 
-  test(testName = "Test for the FLR function") {
+  test(testName = "Test for the FLOOR function") {
     val module = ScalaParser.parseResource("stdlib/FLRTest.oberon")
 
-    assert(module.name == "FLRTest")
+    assert(module.name == "FLOORTest")
 
     val interpreter = new Interpreter
     interpreter.setTestEnvironment()
 
     module.accept(interpreter)
 
-    assert(interpreter.env.lookup("y") == Some(RealValue(10.0)))
-    assert(interpreter.env.lookup("z") == Some(RealValue(50.0)))
+    assert(interpreter.env.lookup("y") == Some(IntValue(10)))
+    assert(interpreter.env.lookup("z") == Some(IntValue(50)))
   }
 
   test(testName = "Test for the RND function") {
@@ -61,8 +61,22 @@ class StandardLibraryTest extends AnyFunSuite {
 
     module.accept(interpreter)
 
-    assert(interpreter.env.lookup("y") == Some(RealValue(10.0)))
-    assert(interpreter.env.lookup("z") == Some(RealValue(-1.0)))
+    assert(interpreter.env.lookup("y") == Some(IntValue(10)))
+    assert(interpreter.env.lookup("z") == Some(IntValue(-1)))
+  }
+
+  test(testName = "Test for the FLT function"){
+    val module = ScalaParser.parseResource("stdlib/FLTTest.oberon")
+
+    assert(module.name == "FLTTest")
+
+    val interpreter = new Interpreter
+    interpreter.setTestEnvironment()
+
+    module.accept(interpreter)
+
+    assert(interpreter.env.lookup("y") == Some(RealValue(-8.0)))
+    assert(interpreter.env.lookup("z") == Some(RealValue(2.0)))
   }
 
   test(testName = "Test for the POW function") {
@@ -103,8 +117,8 @@ class StandardLibraryTest extends AnyFunSuite {
 
     module.accept(interpreter)
 
-    assert(interpreter.env.lookup("z") == Some(RealValue(10.0)))
-    assert(interpreter.env.lookup("w") == Some(RealValue(12.0)))
+    assert(interpreter.env.lookup("z") == Some(IntValue(10)))
+    assert(interpreter.env.lookup("w") == Some(IntValue(12)))
 
   }
 


### PR DESCRIPTION
Adds the "~" (logical not),  "INC " (i++) , "DEC" (i--) and MOD to parser and interpreter. Adds test cases for those functions in InterpreterTest.

Fixes the procedures "FLOOR" , "CEIL", "RND" (round) and adds FLT in StandardLibrary. Adds test cases for those procedures in procedures in StandardLibraryTest.

Adds an ignored test case for the array assignment in InterpreterTest.