### PR TITLE
Fix OberonCore WhileStmt statement block not converting properly

### DIFF
--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -27,6 +27,9 @@ class CoreVisitor extends OberonVisitorAdapter {
 
     case CaseStmt(exp, cases, elseStmt) => transformCase(exp, cases, elseStmt)
 
+    case WhileStmt(condition, stmt) =>
+      WhileStmt(condition, stmt.accept(this))
+
     case _ => stmt
   }
 


### PR DESCRIPTION
# Changes
* The statement list within WhileStmt statements are now being converted by CoreTransformer.scala