### PR TITLE
Group 4 Sprint 1 - Remove non OberonCore support from Interpreter

### DIFF
--- a/src/main/scala/br/unb/cic/oberon/interpreter/Interpreter.scala
+++ b/src/main/scala/br/unb/cic/oberon/interpreter/Interpreter.scala
@@ -140,54 +140,6 @@ class Interpreter extends OberonVisitorAdapter {
     }
   }
 
-  // Moving forward, only modules converted to OberonCore should be accepted.
-  // The following two functions are meant to be used in interpreting
-  // IfElseIfStmt and CaseStmt, respectively. Since these types are
-  // no longer to be supported, they are currently disabled.
-
-  // private def checkIfElseIfStmt(condition: Expression, thenStmt: Statement, listOfElseIf: List[ElseIfStmt], elseStmt: Option[Statement]): Unit = {
-  //   var matched = false
-  //   var i = 0
-  // 
-  //   if (evalCondition(condition)) thenStmt.accept(this)
-  //   else {
-  //     while (i < listOfElseIf.size && !matched) {
-  //       listOfElseIf(i) match {
-  //         case ElseIfStmt(condition, stmt) => if (evalCondition(condition)) {
-  //           stmt.accept(this)
-  //           matched = true
-  //         }
-  //       }
-  //       i += 1
-  //     }
-  //     if (!matched && elseStmt.isDefined) elseStmt.get.accept(this)
-  //   }
-  // }
-
-  // private def checkCaseStmt(exp: Expression, cases: List[CaseAlternative], elseStmt: Option[Statement]): Unit = {
-  //   val v = evalExpression(exp)
-  //   var matched = false
-  //   var i = 0
-  //   while (i < cases.size && !matched) {
-  //     cases(i) match {
-  //       case RangeCase(min, max, stmt) =>
-  //         if ((evalCaseAlt(v) >= evalCaseAlt(min)) && (evalCaseAlt(v) <= evalCaseAlt(max))) {
-  //           stmt.accept(this)
-  //           matched = true
-  //         }
-  //       case SimpleCase(condition, stmt) =>
-  //         if (v == evalExpression(condition)) {
-  //           stmt.accept(this)
-  //           matched = true
-  //         }
-  //     }
-  //     i += 1
-  //   }
-  //   if (!matched && elseStmt.isDefined) {
-  //     elseStmt.get.accept(this)
-  //   }
-  // }
-
   /*
    * process the ReturnStmt(exp) statement.
    * In this case, we just create a new entry
@@ -221,11 +173,6 @@ class Interpreter extends OberonVisitorAdapter {
     val evalVisitor = new EvalExpressionVisitor(this)
     expression.accept(evalVisitor)
   }
-
-  // def evalCaseAlt(expression: Expression): Integer = {
-  //   val evalVisitor = new EvalExpressionVisitor(interpreter = this)
-  //   expression.accept(evalVisitor).asInstanceOf[IntValue].value
-  // }
 
   /*
    * This method is mostly useful for testing purposes.

--- a/src/main/scala/br/unb/cic/oberon/interpreter/Interpreter.scala
+++ b/src/main/scala/br/unb/cic/oberon/interpreter/Interpreter.scala
@@ -43,8 +43,8 @@ class Interpreter extends OberonVisitorAdapter {
     module.procedures.foreach(p => p.accept(this))
     module.userTypes.foreach(userType => userType.accept(this))
 
-    // execute the statement, if it is defined. remember,
-    // module.stmt is an Option[Statement].
+    // execute the statement if it is defined.
+    // remember, module.stmt is an Option[Statement].
     if (module.stmt.isDefined) {
       setupStandardLibraries()
       module.stmt.get.accept(this)
@@ -68,11 +68,11 @@ class Interpreter extends OberonVisitorAdapter {
   }
 
   override def visit(stmt: Statement): Unit = {
-    // we first check if we achieved a return stmt.
+    // we first check if we have encountered a return stmt.
     // if so, we should not execute any other statement
-    // of a sequence of stmts. Whenever we achieve a
-    // return stmt, we associate a local variables
-    // "return" to the return value.
+    // of a sequence of stmts. Whenever we encounter a
+    // return stmt, we assign a new local variable
+    // "return" as the return value.
     //
     // we also check if exit is true. if this is the case
     // we should also stop the execution of a block of
@@ -116,36 +116,13 @@ class Interpreter extends OberonVisitorAdapter {
         if (evalCondition(condition)) thenStmt.accept(this)
         else if (elseStmt.isDefined) elseStmt.get.accept(this)
 
-      case IfElseIfStmt(condition, thenStmt, listOfElseIf, elseStmt) =>
-        checkIfElseIfStmt(condition, thenStmt, listOfElseIf, elseStmt)
-
       case WhileStmt(condition, whileStmt) =>
         while (evalCondition(condition) && exit == false )
           whileStmt.accept(this)
         exit = false
 
-      case RepeatUntilStmt(condition, repeatUntilStmt) =>
-        do {
-          repeatUntilStmt.accept(this)
-          val c = evalCondition(condition)
-        }
-        while (!evalCondition(condition))
-
-      case ForStmt(init, condition, block) =>
-        init.accept(this)
-        while (evalCondition(condition))
-          block.accept(this)
-
-      case LoopStmt(stmt) =>
-        while (!exit) {
-          stmt.accept(this)
-        }
-        exit = false
       case ExitStmt() =>
         exit = true
-
-      case CaseStmt(exp, cases, elseStmt) =>
-        checkCaseStmt(exp, cases, elseStmt)
 
       case ReturnStmt(exp: Expression) =>
         setReturnExpression(evalExpression(exp))
@@ -154,54 +131,98 @@ class Interpreter extends OberonVisitorAdapter {
 
       case ProcedureCallStmt(name, args) =>
         val actualArguments = args.map(a => evalExpression(a))
-        env.push() // after that, we can "push", to indicate a procedure call.
+        env.push() // after that, we can "push" to indicate a procedure call.
         visitProcedureCall(name, actualArguments) // then we execute the procedure.
-        env.pop() // and we pop, to indicate that a procedure finished its execution.
+        env.pop() // and we pop to indicate that a procedure finished its execution.
+
+      // The following cases are to phased out as the interpreter is changed
+      // to only support OberonCore statements.
+
+      case CaseStmt(exp, cases, elseStmt) =>
+        throw new Exception("Modules should be converted to OberonCore before calling the interpreter; CaseStmt no longer supported.")
+        // old body:
+        // checkCaseStmt(exp, cases, elseStmt)
+
+      case IfElseIfStmt(condition, thenStmt, listOfElseIf, elseStmt) =>
+        throw new Exception("Modules should be converted to OberonCore before calling the interpreter; IfElseIfStmt no longer supported.")
+        // old body:
+        // checkIfElseIfStmt(condition, thenStmt, listOfElseIf, elseStmt)
+
+      case RepeatUntilStmt(condition, repeatUntilStmt) =>
+        throw new Exception("Modules should be converted to OberonCore before calling the interpreter; RepeatUntilStmt no longer supported.")
+        // old body:
+        // do {
+        //   repeatUntilStmt.accept(this)
+        //   val c = evalCondition(condition)
+        // }
+        // while (!evalCondition(condition))
+
+      case ForStmt(init, condition, block) =>
+        throw new Exception("Modules should be converted to OberonCore before calling the interpreter; ForStmt no longer supported.")
+        // old body:
+        // init.accept(this)
+        // while (evalCondition(condition))
+        //   block.accept(this)
+
+      case LoopStmt(stmt) =>
+        throw new Exception("Modules should be converted to OberonCore before calling the interpreter; LoopStmt no longer supported.")
+        // old body:
+        // while (!exit) {
+        //   stmt.accept(this)
+        // }
+        // exit = false
+      
+      case _ => throw new Exception("Module contains statement type unsupported by the interpreter.")
     }
   }
 
-  private def checkIfElseIfStmt(condition: Expression, thenStmt: Statement, listOfElseIf: List[ElseIfStmt], elseStmt: Option[Statement]): Unit = {
-    var matched = false
-    var i = 0
+  // Moving forward, only modules converted to OberonCore should be accepted.
+  // The following two functions are meant to be used in interpreting
+  // IfElseIfStmt and CaseStmt, respectively. Since these types are
+  // no longer to be supported, they are currently disabled.
 
-    if (evalCondition(condition)) thenStmt.accept(this)
-    else {
-      while (i < listOfElseIf.size && !matched) {
-        listOfElseIf(i) match {
-          case ElseIfStmt(condition, stmt) => if (evalCondition(condition)) {
-            stmt.accept(this)
-            matched = true
-          }
-        }
-        i += 1
-      }
-      if (!matched && elseStmt.isDefined) elseStmt.get.accept(this)
-    }
-  }
+  // private def checkIfElseIfStmt(condition: Expression, thenStmt: Statement, listOfElseIf: List[ElseIfStmt], elseStmt: Option[Statement]): Unit = {
+  //   var matched = false
+  //   var i = 0
+  // 
+  //   if (evalCondition(condition)) thenStmt.accept(this)
+  //   else {
+  //     while (i < listOfElseIf.size && !matched) {
+  //       listOfElseIf(i) match {
+  //         case ElseIfStmt(condition, stmt) => if (evalCondition(condition)) {
+  //           stmt.accept(this)
+  //           matched = true
+  //         }
+  //       }
+  //       i += 1
+  //     }
+  //     if (!matched && elseStmt.isDefined) elseStmt.get.accept(this)
+  //   }
+  // }
 
-  private def checkCaseStmt(exp: Expression, cases: List[CaseAlternative], elseStmt: Option[Statement]): Unit = {
-    val v = evalExpression(exp)
-    var matched = false
-    var i = 0
-    while (i < cases.size && !matched) {
-      cases(i) match {
-        case RangeCase(min, max, stmt) =>
-          if ((evalCaseAlt(v) >= evalCaseAlt(min)) && (evalCaseAlt(v) <= evalCaseAlt(max))) {
-            stmt.accept(this)
-            matched = true
-          }
-        case SimpleCase(condition, stmt) =>
-          if (v == evalExpression(condition)) {
-            stmt.accept(this)
-            matched = true
-          }
-      }
-      i += 1
-    }
-    if (!matched && elseStmt.isDefined) {
-      elseStmt.get.accept(this)
-    }
-  }
+  // private def checkCaseStmt(exp: Expression, cases: List[CaseAlternative], elseStmt: Option[Statement]): Unit = {
+  //   val v = evalExpression(exp)
+  //   var matched = false
+  //   var i = 0
+  //   while (i < cases.size && !matched) {
+  //     cases(i) match {
+  //       case RangeCase(min, max, stmt) =>
+  //         if ((evalCaseAlt(v) >= evalCaseAlt(min)) && (evalCaseAlt(v) <= evalCaseAlt(max))) {
+  //           stmt.accept(this)
+  //           matched = true
+  //         }
+  //       case SimpleCase(condition, stmt) =>
+  //         if (v == evalExpression(condition)) {
+  //           stmt.accept(this)
+  //           matched = true
+  //         }
+  //     }
+  //     i += 1
+  //   }
+  //   if (!matched && elseStmt.isDefined) {
+  //     elseStmt.get.accept(this)
+  //   }
+  // }
 
   /*
    * process the ReturnStmt(exp) statement.
@@ -237,14 +258,14 @@ class Interpreter extends OberonVisitorAdapter {
     expression.accept(evalVisitor)
   }
 
-  def evalCaseAlt(expression: Expression): Integer = {
-    val evalVisitor = new EvalExpressionVisitor(interpreter = this)
-    expression.accept(evalVisitor).asInstanceOf[IntValue].value
-  }
+  // def evalCaseAlt(expression: Expression): Integer = {
+  //   val evalVisitor = new EvalExpressionVisitor(interpreter = this)
+  //   expression.accept(evalVisitor).asInstanceOf[IntValue].value
+  // }
 
   /*
-   * This method is mostly useful for testing purpose.
-   * That is, here we are considering testability as a
+   * This method is mostly useful for testing purposes.
+   * That is, here we are considering testability a
    * design concern.
    */
   def setGlobalVariable(name: String, exp: Expression): Unit = {

--- a/src/test/scala/br/unb/cic/oberon/interpreter/InterpreterTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/interpreter/InterpreterTest.scala
@@ -4,6 +4,7 @@ import java.nio.file.{Files, Paths}
 
 import br.unb.cic.oberon.ast._
 import br.unb.cic.oberon.parser.ScalaParser
+import br.unb.cic.oberon.transformations.CoreVisitor
 import org.scalatest.funsuite.AnyFunSuite
 import scala.collection.mutable.ListBuffer
 
@@ -16,10 +17,13 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_stmt01 program") {
     val module = ScalaParser.parseResource("stmts/interpreter_stmt01.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(5))) // FOR TO x
     assert(interpreter.env.lookup("y") == Some(IntValue(6))) // y = x + 1 (after last FOR)
@@ -30,9 +34,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_factorial01 program: factorial(5)") {
     val module = ScalaParser.parseResource("procedures/interpreter_factorial01.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(1)))
     assert(interpreter.env.lookup("y") == Some(IntValue(120)))
@@ -42,9 +49,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_factorial02 program: factorial(1)") {
     val module = ScalaParser.parseResource("procedures/interpreter_factorial02.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(1)))
     assert(interpreter.env.lookup("y") == Some(IntValue(1)))
@@ -54,9 +64,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_factorial03 program: factorial(0)") {
     val module = ScalaParser.parseResource("procedures/interpreter_factorial03.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(0)))
     assert(interpreter.env.lookup("y") == Some(IntValue(1)))
@@ -66,7 +79,10 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_fibonacci program: Fibonacci index 7 = 13") {
     val module = ScalaParser.parseResource("procedures/interpreter_fibonacci01.oberon")
 
-    module.accept(interpreter)
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("ant") == Some(IntValue(13)))
 
@@ -74,9 +90,13 @@ class InterpreterTest extends AnyFunSuite {
 
   test("Testing interpreter on interpreter_stmt02 program") {
     val module = ScalaParser.parseResource("stmts/interpreter_stmt02.oberon")
-    assert(module.name == "SimpleModule")
 
-    module.accept(interpreter)
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
+
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(15)))
     assert(interpreter.env.lookup("z") == Some(IntValue(18)))
@@ -86,9 +106,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_stmt03 program") {
     val module = ScalaParser.parseResource("stmts/interpreter_stmt03.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(90)))
     assert(interpreter.env.lookup("z") == Some(IntValue(0)))
@@ -98,9 +121,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_stmt04 program") {
     val module = ScalaParser.parseResource("stmts/interpreter_stmt04.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(101)))
     assert(interpreter.env.lookup("z") == Some(IntValue(0)))
@@ -110,9 +136,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_stmt05 program") {
     val module = ScalaParser.parseResource("stmts/interpreter_stmt05.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(101)))
     assert(interpreter.env.lookup("z") == Some(IntValue(2)))
@@ -122,9 +151,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_stmt06 program") {
     val module = ScalaParser.parseResource("stmts/interpreter_stmt06.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(52)))
     assert(interpreter.env.lookup("z") == Some(IntValue(10)))
@@ -134,9 +166,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_stmt07 program") {
     val module = ScalaParser.parseResource("stmts/interpreter_stmt07.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(52)))
     assert(interpreter.env.lookup("z") == Some(IntValue(10)))
@@ -145,9 +180,13 @@ class InterpreterTest extends AnyFunSuite {
 
   test("Testing interpreter on interpreter_fibonacci02 program: Fibonacci index 10 = 55") {
     val module = ScalaParser.parseResource("procedures/interpreter_fibonacci02.oberon")
-    assert(module.name == "SimpleModule")
+    
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("ant") == Some(IntValue(55)))
   }
@@ -155,9 +194,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_factorial04 program: factorial(4)") {
     val module = ScalaParser.parseResource("procedures/interpreter_factorial04.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(1)))
     assert(interpreter.env.lookup("y") == Some(IntValue(24)))
@@ -167,9 +209,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_stmt08 program") {
     val module = ScalaParser.parseResource("stmts/interpreter_stmt08.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(-50)))
     assert(interpreter.env.lookup("z") == Some(IntValue(10)))
@@ -179,9 +224,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing interpreter on interpreter_stmt09 program") {
     val module = ScalaParser.parseResource("stmts/interpreter_stmt09.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(25)))
     assert(interpreter.env.lookup("z") == Some(IntValue(10)))
@@ -191,9 +239,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing IFELSEIF stmt on IfElseIfStmt01 program") {
     val module = ScalaParser.parseResource("stmts/IfElseIfStmt01.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("y") == Some(IntValue(1)));
 
@@ -202,9 +253,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing IFELSEIF stmt on IfElseIfStmt02 program") {
     val module = ScalaParser.parseResource("stmts/IfElseIfStmt02.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("y") == Some(IntValue(2)));
 
@@ -213,9 +267,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing IFELSEIF stmt on IfElseIfStmt03 program") {
     val module = ScalaParser.parseResource("stmts/IfElseIfStmt03.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("y") == Some(IntValue(3)));
 
@@ -224,9 +281,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing IFELSEIF stmt on IfElseIfStmt04 program") {
     val module = ScalaParser.parseResource("stmts/IfElseIfStmt04.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("y") == Some(IntValue(4)));
 
@@ -235,9 +295,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing IFELSEIF stmt on IfElseIfStmt05 program") {
     val module = ScalaParser.parseResource("stmts/IfElseIfStmt05.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("y") == Some(IntValue(5)));
 
@@ -246,9 +309,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing IFELSEIF stmt on IfElseIfStmt06 program") {
     val module = ScalaParser.parseResource("stmts/IfElseIfStmt06.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("y") == Some(IntValue(2)));
 
@@ -257,9 +323,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing IFELSEIF stmt on IfElseIfStmt07 program") {
     val module = ScalaParser.parseResource("stmts/IfElseIfStmt07.oberon")
 
-    assert(module.name == "SimpleModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("y") == Some(IntValue(2)));
 
@@ -267,9 +336,13 @@ class InterpreterTest extends AnyFunSuite {
 
   test("Testing IFELSEIF stmt on IfElseIfStmt08 program") {
     val module = ScalaParser.parseResource("stmts/IfElseIfStmt08.oberon")
-    assert(module.name == "SimpleModule")
 
-    module.accept(interpreter)
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
+
+    assert(coreModule.name == "SimpleModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("y") == Some(IntValue(3)));
 
@@ -277,9 +350,13 @@ class InterpreterTest extends AnyFunSuite {
 
   test("Testing RepeatUntil stmt on RepeatUntilStmt01 program") {
     val module = ScalaParser.parseResource("stmts/RepeatUntilStmt01.oberon")
-    assert(module.name == "RepeatUntilModule")
 
-    module.accept(interpreter)
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
+
+    assert(coreModule.name == "RepeatUntilModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x").contains(IntValue(11)));
     assert(interpreter.env.lookup("sum").contains(IntValue(55)));
@@ -289,9 +366,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing RepeatUntil stmt on RepeatUntilStmt02 program") {
     val module = ScalaParser.parseResource("stmts/RepeatUntilStmt02.oberon")
 
-    assert(module.name == "RepeatUntilModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "RepeatUntilModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("sum") == Some(IntValue(330)));
     assert(interpreter.env.lookup("x") == Some(IntValue(21)));
@@ -301,9 +381,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing RepeatUntil stmt on RepeatUntilStmt03 program") {
     val module = ScalaParser.parseResource("stmts/RepeatUntilStmt03.oberon")
 
-    assert(module.name == "RepeatUntilModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "RepeatUntilModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("sum") == Some(IntValue(11)));
 
@@ -312,9 +395,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing RepeatUntil stmt on RepeatUntilStmt04 program") {
     val module = ScalaParser.parseResource("stmts/RepeatUntilStmt04.oberon")
 
-    assert(module.name == "RepeatUntilModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "RepeatUntilModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(20)));
 
@@ -323,9 +409,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing RepeatUntil stmt on RepeatUntilStmt05 program") {
     val module = ScalaParser.parseResource("stmts/RepeatUntilStmt05.oberon")
 
-    assert(module.name == "RepeatUntilModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "RepeatUntilModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(0)));
 
@@ -334,8 +423,11 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing RepeatUntil stmt on RepeatUntilStmt06 program") {
     val module = ScalaParser.parseResource("stmts/RepeatUntilStmt06.oberon")
 
-    assert(module.name == "RepeatUntilModule")
-    module.accept(interpreter)
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
+
+    assert(coreModule.name == "RepeatUntilModule")
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(11)));
     assert(interpreter.env.lookup("y") == Some(IntValue(40)));
@@ -345,9 +437,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing RepeatUntil stmt on RepeatUntilStmt07 program") {
     val module = ScalaParser.parseResource("stmts/RepeatUntilStmt07.oberon")
 
-    assert(module.name == "RepeatUntilModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "RepeatUntilModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(3)));
     assert(interpreter.env.lookup("y") == Some(IntValue(3)));
@@ -356,9 +451,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Testing RepeatUntil stmt on RepeatUntilStmt08 program") {
     val module = ScalaParser.parseResource("stmts/RepeatUntilStmt08.oberon")
 
-    assert(module.name == "RepeatUntilModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "RepeatUntilModule")
+
+    coreModule.accept(interpreter)
 
     assert(interpreter.env.lookup("x") == Some(IntValue(10)));
     assert(interpreter.env.lookup("y") == Some(IntValue(10)));
@@ -372,9 +470,12 @@ class InterpreterTest extends AnyFunSuite {
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "LoopStmt")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "LoopStmt")
+
+    coreModule.accept(interpreter)
     assert(interpreter.env.lookup("x") == Some(IntValue(-1)))
   }
 
@@ -386,9 +487,12 @@ class InterpreterTest extends AnyFunSuite {
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "LoopStmt")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "LoopStmt")
+
+    coreModule.accept(interpreter)
     assert(interpreter.env.lookup("x") == Some(IntValue(6)))
     assert(interpreter.env.lookup("factorial") == Some(IntValue(120)))
   }
@@ -401,9 +505,12 @@ class InterpreterTest extends AnyFunSuite {
     val content = String.join("\n", Files.readAllLines(path))
     val module = ScalaParser.parse(content)
 
-    assert(module.name == "LoopStmt")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "LoopStmt")
+
+    coreModule.accept(interpreter)
     assert(interpreter.env.lookup("x") == Some(IntValue(10)))
     assert(interpreter.env.lookup("y") == Some(IntValue(100)))
   }
@@ -411,9 +518,12 @@ class InterpreterTest extends AnyFunSuite {
   test("stmt35") {
     val module = ScalaParser.parseResource("stmts/stmt35.oberon")
 
-    assert(module.name == "UserTypeModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "UserTypeModule")
+
+    coreModule.accept(interpreter)
     assert(interpreter.env.lookupArrayIndex("a", 0).contains(IntValue(5)))
     assert(interpreter.env.lookupArrayIndex("b", 1).contains(IntValue(10)))
   }
@@ -421,9 +531,12 @@ class InterpreterTest extends AnyFunSuite {
   test("stmt36") {
     val module = ScalaParser.parseResource("stmts/stmt36.oberon")
 
-    assert(module.name == "UserTypeModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "UserTypeModule")
+
+    coreModule.accept(interpreter)
     assert(interpreter.env.lookupArrayIndex("a", 0).contains(IntValue(5)))
     assert(interpreter.env.lookupArrayIndex("a", 1).contains(IntValue(10)))
     assert(interpreter.env.lookupArrayIndex("b", 0).contains(IntValue(10)))
@@ -433,9 +546,12 @@ class InterpreterTest extends AnyFunSuite {
   test("stmt37") {
     val module = ScalaParser.parseResource("stmts/stmt37.oberon")
 
-    assert(module.name == "UserTypeModule")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "UserTypeModule")
+
+    coreModule.accept(interpreter)
     assert(interpreter.env.lookupArrayIndex("a", 0).contains(IntValue(5)))
     assert(interpreter.env.lookupArrayIndex("a", 2).contains(IntValue(25)))
   }
@@ -443,9 +559,12 @@ class InterpreterTest extends AnyFunSuite {
   test("Module A has no imports"){
     val module = ScalaParser.parseResource("imports/A.oberon")
 
-    assert(module.name == "A")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "A")
+
+    coreModule.accept(interpreter)
     assert(interpreter.env.lookup("x").isDefined)
     assert(interpreter.env.lookup("x") == Some(IntValue(1)))
   }
@@ -453,9 +572,12 @@ class InterpreterTest extends AnyFunSuite {
   ignore("Module B imports A"){
     val module = ScalaParser.parseResource("imports/B.oberon")
 
-    assert(module.name == "B")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "B")
+
+    coreModule.accept(interpreter)
     assert(interpreter.env.lookup("x").isDefined)
     assert(interpreter.env.lookup("x") == Some(IntValue(1)))
   }
@@ -464,9 +586,12 @@ class InterpreterTest extends AnyFunSuite {
   ignore("Module F imports A using alias"){
     val module = ScalaParser.parseResource("imports/F.oberon")
 
-    assert(module.name == "F")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "F")
+
+    coreModule.accept(interpreter)
     assert(interpreter.env.lookup("x").isDefined)
     assert(interpreter.env.lookup("x") == Some(IntValue(1)))
   }
@@ -474,9 +599,12 @@ class InterpreterTest extends AnyFunSuite {
   ignore("Module D imports A and C (A and C hava a variable 'x')"){
     val module = ScalaParser.parseResource("imports/D.oberon")
 
-    assert(module.name == "D")
+    val coreVisitor = new CoreVisitor()
+    val coreModule = coreVisitor.transformModule(module)
 
-    module.accept(interpreter)
+    assert(coreModule.name == "D")
+
+    coreModule.accept(interpreter)
     assert(interpreter.env.lookup("x").isDefined)
     assert(interpreter.env.lookup("x") == Some(IntValue(1)))
     //assert(interpreter.env.lookup("x") == Some(IntValue(2)))


### PR DESCRIPTION
## Changes
* Interpreter no longer supports non OberonCore statements. All modules should be converted by calling CoreVisitor from the CoreTransformer module before calling the interpreter from now on.
* Updated all tests in InterpreterTest to reflect the current design (All unit tests now convert the tested module to OberonCore before running).
* Cleaned up some comments and corrected spelling mistakes.

### Group 4 -- Students
João Pedro Martins - 20/0020692
Cláudio Barros - 19/0097591
Gabriel Santos Menezes - 17/0050157
Léo Akira Abe Barros - 18/0137531