### PR TITLE
Fix CaseStmt core transformation repetition of exp

### DIFF
--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -5,9 +5,10 @@ import br.unb.cic.oberon.visitor.OberonVisitorAdapter
 import scala.collection.mutable.ListBuffer
 import br.unb.cic.oberon.ast.Procedure
 
-class CoreVisitor(var addedVariables: List[VariableDeclaration] = Nil) extends OberonVisitorAdapter {
-
+class CoreVisitor() extends OberonVisitorAdapter {
   override type T = Statement
+  
+  var addedVariables: List[VariableDeclaration] = Nil
 
   override def visit(stmt: Statement): Statement = stmt match {
     case SequenceStmt(stmts) =>


### PR DESCRIPTION
# Changes
- Transformation of CaseStmt now avoids repetition of the CaseStmt's expression.