### PR TITLE
TypeChecker REAL verification and a variety of test cases. - Grupo 3

### DIFF
--- a/src/main/scala/br/unb/cic/oberon/tc/TypeChecker.scala
+++ b/src/main/scala/br/unb/cic/oberon/tc/TypeChecker.scala
@@ -37,13 +37,13 @@ class ExpressionTypeVisitor(val typeChecker: TypeChecker) extends OberonVisitorA
     case LTEExpression(left, right) =>
       computeBinExpressionType(left, right, List(IntegerType), BooleanType)
     case AddExpression(left, right) =>
-      computeBinExpressionType(left, right, List(IntegerType), IntegerType)
+      computeArithmethicBinExpressionType(left, right)
     case SubExpression(left, right) =>
-      computeBinExpressionType(left, right, List(IntegerType), IntegerType)
+      computeArithmethicBinExpressionType(left, right)
     case MultExpression(left, right) =>
-      computeBinExpressionType(left, right, List(IntegerType), IntegerType)
+      computeArithmethicBinExpressionType(left, right)
     case DivExpression(left, right) =>
-      computeBinExpressionType(left, right, List(IntegerType), IntegerType)
+      computeArithmethicBinExpressionType(left, right)
     case AndExpression(left, right) =>
       computeBinExpressionType(left, right, List(BooleanType), BooleanType)
     case OrExpression(left, right) =>
@@ -129,6 +129,21 @@ class ExpressionTypeVisitor(val typeChecker: TypeChecker) extends OberonVisitorA
     val t2 = right.accept(this)
     if(t1 == t2 && expected.contains(t1.getOrElse(None))) Some(result) else None
   }
+
+  def computeArithmethicBinExpressionType[A](left: Expression, right: Expression) : Option[Type] = {
+    val t1 = left.accept(this).getOrElse()
+    val t2 = right.accept(this).getOrElse()
+    
+    if(t1 == IntegerType && t2 == IntegerType) Some(IntegerType)
+
+    else if(t1 == RealType && t2 == RealType    ||
+            t1 == RealType && t2 == IntegerType ||
+            t1 == IntegerType && t2 == RealType) 
+            Some(RealType)
+    
+    else None
+  }
+
 }
 
 class TypeChecker extends OberonVisitorAdapter {

--- a/src/test/resources/stmts/tc_CharPointerAssignmentWrong.oberon
+++ b/src/test/resources/stmts/tc_CharPointerAssignmentWrong.oberon
@@ -1,0 +1,15 @@
+MODULE pointer;
+
+VAR
+  p : POINTER TO REAL;
+  x : CHAR;
+
+BEGIN
+    x := 'b';
+    p^ := 'a';
+    x := p;
+    p := x
+    
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_CharPointerNull.oberon
+++ b/src/test/resources/stmts/tc_CharPointerNull.oberon
@@ -1,0 +1,12 @@
+MODULE pointer;
+
+VAR
+    p : POINTER TO CHAR;
+
+
+BEGIN
+    p := NIL
+
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_CharPointerValueNull.oberon
+++ b/src/test/resources/stmts/tc_CharPointerValueNull.oberon
@@ -1,0 +1,12 @@
+MODULE pointer;
+
+VAR
+    p : POINTER TO CHAR;
+
+
+BEGIN
+    p^ := NIL
+
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_IntegerDivOperation.oberon
+++ b/src/test/resources/stmts/tc_IntegerDivOperation.oberon
@@ -1,0 +1,15 @@
+MODULE DivOperation;
+
+VAR
+  x : INTEGER;
+  y : INTEGER;
+  div : INTEGER;
+
+BEGIN
+    x := 20;
+    y := 10;
+    div := x / y
+    
+END
+
+END DivOperation.

--- a/src/test/resources/stmts/tc_IntegerMultOperation.oberon
+++ b/src/test/resources/stmts/tc_IntegerMultOperation.oberon
@@ -1,0 +1,15 @@
+MODULE MultOperation;
+
+VAR
+  x : INTEGER;
+  y : INTEGER;
+  mult : INTEGER;
+
+BEGIN
+    x := 10;
+    y := 10;
+    mult := x * y
+    
+END
+
+END MultOperation.

--- a/src/test/resources/stmts/tc_IntegerRecordOperation.oberon
+++ b/src/test/resources/stmts/tc_IntegerRecordOperation.oberon
@@ -1,0 +1,18 @@
+MODULE SimpleModule;
+
+TYPE
+   rec = RECORD
+      x: INTEGER;
+      y: INTEGER;
+   END
+
+VAR
+    r : rec;
+BEGIN
+    r.x := 5;
+    r.y := 10;
+    r.x := r.x + r.y
+    
+END
+
+END SimpleModule.

--- a/src/test/resources/stmts/tc_IntegerSubOperation.oberon
+++ b/src/test/resources/stmts/tc_IntegerSubOperation.oberon
@@ -1,0 +1,15 @@
+MODULE pointer;
+
+VAR
+  x : INTEGER;
+  y : INTEGER;
+  sub : INTEGER;
+
+BEGIN
+    x := 10;
+    y := 20;
+    sub := x - 78
+    
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_IntegerSubOperation.oberon
+++ b/src/test/resources/stmts/tc_IntegerSubOperation.oberon
@@ -1,4 +1,4 @@
-MODULE pointer;
+MODULE SubOperation;
 
 VAR
   x : INTEGER;
@@ -12,4 +12,4 @@ BEGIN
     
 END
 
-END pointer.
+END SubOperation.

--- a/src/test/resources/stmts/tc_IntegerSumOperation.oberon
+++ b/src/test/resources/stmts/tc_IntegerSumOperation.oberon
@@ -1,0 +1,15 @@
+MODULE pointer;
+
+VAR
+  x : INTEGER;
+  y : INTEGER;
+  sum : INTEGER;
+
+BEGIN
+    x := 10;
+    y := 20;
+    sum := x + 78
+    
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_IntegerSumOperation.oberon
+++ b/src/test/resources/stmts/tc_IntegerSumOperation.oberon
@@ -1,4 +1,4 @@
-MODULE pointer;
+MODULE SumOperation;
 
 VAR
   x : INTEGER;
@@ -12,4 +12,4 @@ BEGIN
     
 END
 
-END pointer.
+END SumOperation.

--- a/src/test/resources/stmts/tc_PointerAcessCharStmt.oberon
+++ b/src/test/resources/stmts/tc_PointerAcessCharStmt.oberon
@@ -1,0 +1,10 @@
+MODULE pointerchar;
+
+VAR
+  p : POINTER TO CHAR;
+
+BEGIN
+    p^ := 'a'
+END
+
+END pointerchar.

--- a/src/test/resources/stmts/tc_PointerBoolFalseCorrect.oberon
+++ b/src/test/resources/stmts/tc_PointerBoolFalseCorrect.oberon
@@ -1,0 +1,12 @@
+MODULE pointer;
+
+VAR
+    p : POINTER TO BOOLEAN;
+    
+
+BEGIN
+    p^ := False
+
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_PointerBoolTrueCorrect.oberon
+++ b/src/test/resources/stmts/tc_PointerBoolTrueCorrect.oberon
@@ -1,0 +1,12 @@
+MODULE pointer;
+
+VAR
+    p : POINTER TO BOOLEAN;
+    
+
+BEGIN
+    p^ := True
+
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_PointerBoolTrueIncorrect.oberon
+++ b/src/test/resources/stmts/tc_PointerBoolTrueIncorrect.oberon
@@ -1,0 +1,12 @@
+MODULE pointer;
+
+VAR
+    p : POINTER TO BOOLEAN;
+    
+
+BEGIN
+    p^ := 10
+
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_PointerCharValueIntValueStmt.oberon
+++ b/src/test/resources/stmts/tc_PointerCharValueIntValueStmt.oberon
@@ -1,0 +1,10 @@
+MODULE pointerchar;
+
+VAR
+  p : POINTER TO CHAR;
+
+BEGIN
+    p^ := 1
+END
+
+END pointerchar.

--- a/src/test/resources/stmts/tc_PointerNullValue.oberon
+++ b/src/test/resources/stmts/tc_PointerNullValue.oberon
@@ -1,0 +1,12 @@
+MODULE pointer;
+
+VAR
+    p : POINTER TO INTEGER;
+
+
+BEGIN
+    p^ := NIL
+
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_PointerValueIntValue.oberon
+++ b/src/test/resources/stmts/tc_PointerValueIntValue.oberon
@@ -1,0 +1,15 @@
+MODULE pointer;
+
+VAR
+  p : POINTER TO INTEGER;
+  x : INTEGER;
+
+BEGIN
+    x := 10;
+    p^ := 20;
+    x := p^;
+    p^ := x
+    
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_RealDivOperation.oberon
+++ b/src/test/resources/stmts/tc_RealDivOperation.oberon
@@ -1,0 +1,15 @@
+MODULE DivOperation;
+
+VAR
+  x : REAL;
+  y : REAL;
+  div : REAL;
+
+BEGIN
+    x := 20.0;
+    y := 10.0;
+    div := x / y
+    
+END
+
+END DivOperation.

--- a/src/test/resources/stmts/tc_RealIntegerDivOperation.oberon
+++ b/src/test/resources/stmts/tc_RealIntegerDivOperation.oberon
@@ -1,0 +1,15 @@
+MODULE DivOperation;
+
+VAR
+  x : REAL;
+  y : INTEGER;
+  div : REAL;
+
+BEGIN
+    x := 20.5;
+    y := 10;
+    div := x / y
+    
+END
+
+END DivOperation.

--- a/src/test/resources/stmts/tc_RealIntegerMultOperation.oberon
+++ b/src/test/resources/stmts/tc_RealIntegerMultOperation.oberon
@@ -1,0 +1,15 @@
+MODULE MultOperation;
+
+VAR
+  x : REAL;
+  y : INTEGER;
+  mult : REAL;
+
+BEGIN
+    x := 30.0;
+    y := 10;
+    mult := x * y
+    
+END
+
+END MultOperation.

--- a/src/test/resources/stmts/tc_RealIntegerSubOperation.oberon
+++ b/src/test/resources/stmts/tc_RealIntegerSubOperation.oberon
@@ -1,0 +1,15 @@
+MODULE SubOperation;
+
+VAR
+  x : REAL;
+  y : INTEGER;
+  sub : REAL;
+
+BEGIN
+    x := 10.5;
+    y := 20;
+    sub := x - y
+    
+END
+
+END SubOperation.

--- a/src/test/resources/stmts/tc_RealIntegerSumOperation.oberon
+++ b/src/test/resources/stmts/tc_RealIntegerSumOperation.oberon
@@ -1,0 +1,15 @@
+MODULE SumOperation;
+
+VAR
+  x : REAL;
+  y : INTEGER;
+  sum : REAL;
+
+BEGIN
+    x := 10.5;
+    y := 20;
+    sum := x + y
+    
+END
+
+END SumOperation.

--- a/src/test/resources/stmts/tc_RealMultOperation.oberon
+++ b/src/test/resources/stmts/tc_RealMultOperation.oberon
@@ -1,0 +1,15 @@
+MODULE MultOperation;
+
+VAR
+  x : REAL;
+  y : REAL;
+  mult : REAL;
+
+BEGIN
+    x := 10.0;
+    y := 10.0;
+    mult := x * y
+    
+END
+
+END MultOperation.

--- a/src/test/resources/stmts/tc_RealPointerAssignment.oberon
+++ b/src/test/resources/stmts/tc_RealPointerAssignment.oberon
@@ -1,0 +1,15 @@
+MODULE pointer;
+
+VAR
+  p : POINTER TO REAL;
+  x : REAL;
+
+BEGIN
+    x := 10.5;
+    p^ := 20.5;
+    x := p^;
+    p^ := x
+    
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_RealPointerAssignmentStmt.oberon
+++ b/src/test/resources/stmts/tc_RealPointerAssignmentStmt.oberon
@@ -1,0 +1,13 @@
+MODULE pointer;
+
+VAR
+  p : POINTER TO REAL;
+
+
+BEGIN
+    p^ := 10.5
+    
+    
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_RealPointerNull.oberon
+++ b/src/test/resources/stmts/tc_RealPointerNull.oberon
@@ -1,0 +1,12 @@
+MODULE pointer;
+
+VAR
+    p : POINTER TO REAL;
+
+
+BEGIN
+    p := NIL
+
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_RealPointerOperation.oberon
+++ b/src/test/resources/stmts/tc_RealPointerOperation.oberon
@@ -1,0 +1,14 @@
+MODULE pointer;
+
+VAR
+  p : POINTER TO REAL;
+  x : REAL;
+
+BEGIN
+    x := 20.5;
+    p^ := 10.5;
+    p^ := x + p^
+    
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_RealPointerOperationWithRealValue.oberon
+++ b/src/test/resources/stmts/tc_RealPointerOperationWithRealValue.oberon
@@ -1,0 +1,19 @@
+MODULE pointer;
+
+VAR
+  p : POINTER TO REAL;
+  q : POINTER TO REAL;
+  y : REAL;
+  x : REAL;
+
+BEGIN
+    y := 30.5;
+    x := 25.5;
+    p^ := y;
+    q^ := x;
+    p^ := x + y;
+    p^ := q^ + p^
+
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_RealPointerValueInteger.oberon
+++ b/src/test/resources/stmts/tc_RealPointerValueInteger.oberon
@@ -1,0 +1,10 @@
+MODULE pointer;
+
+VAR
+  p : POINTER TO INTEGER;
+
+BEGIN
+    p^ := 20.1
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_RealPointerValueNull.oberon
+++ b/src/test/resources/stmts/tc_RealPointerValueNull.oberon
@@ -1,0 +1,12 @@
+MODULE pointer;
+
+VAR
+    p : POINTER TO REAL;
+
+
+BEGIN
+    p^ := NIL
+
+END
+
+END pointer.

--- a/src/test/resources/stmts/tc_RealRecordOperation.oberon
+++ b/src/test/resources/stmts/tc_RealRecordOperation.oberon
@@ -1,0 +1,18 @@
+MODULE SimpleModule;
+
+TYPE
+   rec = RECORD
+      x: REAL;
+      y: REAL;
+   END
+
+VAR
+    r : rec;
+BEGIN
+    r.x := 5.0;
+    r.y := 10.5;
+    r.x := r.x + r.y
+    
+END
+
+END SimpleModule.

--- a/src/test/resources/stmts/tc_RealSubOperation.oberon
+++ b/src/test/resources/stmts/tc_RealSubOperation.oberon
@@ -1,0 +1,15 @@
+MODULE SubOperation;
+
+VAR
+  x : REAL;
+  y : REAL;
+  sub : REAL;
+
+BEGIN
+    x := 20.0;
+    y := 10.0;
+    sub := x - y
+    
+END
+
+END SubOperation.

--- a/src/test/resources/stmts/tc_RealSumOperation.oberon
+++ b/src/test/resources/stmts/tc_RealSumOperation.oberon
@@ -1,0 +1,15 @@
+MODULE SumOperation;
+
+VAR
+  x : REAL;
+  y : REAL;
+  sum : REAL;
+
+BEGIN
+    x := 10.5;
+    y := 20.5;
+    sum := x + y
+    
+END
+
+END SumOperation.

--- a/src/test/resources/stmts/tc_RecordAssigment.oberon
+++ b/src/test/resources/stmts/tc_RecordAssigment.oberon
@@ -1,0 +1,23 @@
+MODULE SimpleModule;
+
+TYPE
+    date = RECORD
+        day: INTEGER;
+        month: REAL;
+        year: STRING;
+        hour: BOOLEAN;
+        array: ARRAY 10 OF INTEGER;
+        
+    END
+VAR
+   d: date;
+BEGIN
+    d.day := 20;
+    d.month := 10.1;
+    d.year := "1992";
+    d.hour := True;
+    d.array[0] := 1
+
+END
+
+END SimpleModule.

--- a/src/test/resources/stmts/tc_RecordAssigmentNull.oberon
+++ b/src/test/resources/stmts/tc_RecordAssigmentNull.oberon
@@ -1,0 +1,14 @@
+MODULE SimpleModule;
+
+TYPE
+   date = RECORD
+      day: INTEGER;
+   END
+
+VAR
+    d1 : date;
+BEGIN
+    d1.day := NIL
+END
+
+END SimpleModule.

--- a/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
+++ b/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
@@ -891,6 +891,8 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
   }
 
 
+  //Pointer Test Cases
+
   test("Test assignment to pointer value") {
     val module = ScalaParser.parseResource("stmts/tc_PointerAccessStmt.oberon")
     val visitor = new TypeChecker()
@@ -932,13 +934,189 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
 
   }
 
-    test("Test assignment of NullValue to pointer") {
+    test("Test assignment of NullValue to integer pointer") {
     val module = ScalaParser.parseResource("stmts/tc_PointerNull.oberon")
     val visitor = new TypeChecker()
     val errors = visitor.visit(module)
 
     assert(errors.size == 0)
 
+  }
+
+    test("Test assignment of NullValue to integer pointer Value") {
+    val module = ScalaParser.parseResource("stmts/tc_PointerNullValue.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 1)
+
+  }
+
+  test("Test assigment INTEGER type pointer to REAL value") {
+    val module = ScalaParser.parseResource("stmts/tc_RealPointerValueInteger.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size > 0)
+
+  }
+
+  // Char Pointer Type Test Cases
+
+  test("Test assignment to pointer value CHAR"){
+    val module = ScalaParser.parseResource("stmts/tc_PointerAcessCharStmt.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+
+  }
+
+  test("Test assignment of Pointer CHAR to NullValue") {
+    val module = ScalaParser.parseResource("stmts/tc_CharPointerNull.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
+ test("Test assignment of Pointer Value CHAR to NullValue") {
+    val module = ScalaParser.parseResource("stmts/tc_CharPointerValueNull.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size > 0)
+  }
+
+  test("Test incorrect assignment between pointer type char and char type variable") {
+    val module = ScalaParser.parseResource("stmts/tc_CharPointerAssignmentWrong.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size > 0)
+  }
+
+  test("Test assigment between pointer type CHAR to INTEGER value "){
+    val module = ScalaParser.parseResource("stmts/tc_PointerCharValueIntValueStmt.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 1)
+
+  }
+
+  // Real Pointer Type Test Cases
+
+   test("Test assignment real to pointer value") {
+    val module = ScalaParser.parseResource("stmts/tc_RealPointerAssignmentStmt.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
+  test("Test assignment of Pointer REAL to NullValue") {
+    val module = ScalaParser.parseResource("stmts/tc_RealPointerNull.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+
+  }
+
+  test("Test assignment of Pointer value REAL to NullValue") {
+    val module = ScalaParser.parseResource("stmts/tc_RealPointerValueNull.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 1)
+
+  }
+
+  test("Test assignment between pointer to real and real type variable") {
+    val module = ScalaParser.parseResource("stmts/tc_RealPointerAssignment.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+
+  }
+
+  test("Test arithmetic operation with pointer real values") {
+    val module = ScalaParser.parseResource("stmts/tc_RealPointerOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
+  test("Test incorrect assignment between pointer to real and arithmetic operation with real") {
+    val module = ScalaParser.parseResource("stmts/tc_RealPointerOperationWithRealValue.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
+  // Boolean Pointer Type Test Cases
+
+  test("Test assignment to pointer boolean type True") {
+    val module = ScalaParser.parseResource("stmts/tc_PointerBoolTrueCorrect.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+  
+  test("Test assignment to pointer boolean type False") {
+    val module = ScalaParser.parseResource("stmts/tc_PointerBoolFalseCorrect.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+  
+  test("Test incorrect assignment to pointer boolean type True") {
+    val module = ScalaParser.parseResource("stmts/tc_PointerBoolTrueIncorrect.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 1)
+  }
+  
+
+  // Record Test Cases
+
+  test("Test Assigment Record to many types") {
+    val module = ScalaParser.parseResource("stmts/tc_RecordAssigment.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+  
+  test("Test Assigment Record Integer element to Null Value") {
+    val module = ScalaParser.parseResource("stmts/tc_RecordAssigmentNull.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 1)
+  }
+
+  test("Test arithmetic operation with record INTEGER element value") {
+    val module = ScalaParser.parseResource("stmts/tc_IntegerRecordOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
+  test("Test arithmetic operation with record REAL element value") {
+    val module = ScalaParser.parseResource("stmts/tc_RealRecordOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
   }
 
   test("Test array subscript") {
@@ -1402,7 +1580,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
 
 
   // Sum test with reals
-  test("Test Real Sum operation") {
+  test("Test Real arithmetic Sum operation") {
     val module = ScalaParser.parseResource("stmts/tc_RealSumOperation.oberon")
     val visitor = new TypeChecker()
     val errors = visitor.visit(module)
@@ -1430,7 +1608,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
   }
 
   // Sub test between reals
-  test("Test Real Sub operation") {
+  test("Test Real arithmetic Sub operation") {
     val module = ScalaParser.parseResource("stmts/tc_RealSubOperation.oberon")
     val visitor = new TypeChecker()
     val errors = visitor.visit(module)
@@ -1457,13 +1635,34 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
   }
 
   // Div test between reals
-  test("Test Real Div operation") {
+  test("Test Real arithmetic Div operation") {
     val module = ScalaParser.parseResource("stmts/tc_RealDivOperation.oberon")
     val visitor = new TypeChecker()
     val errors = visitor.visit(module)
 
     assert(errors.size == 0)
   }
+
+
+  //Div test between real and integer
+  test("Test Real and Integer arithmetic Div operation") {
+    val module = ScalaParser.parseResource("stmts/tc_RealIntegerDivOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
+
+  // Mult test between integers
+  test("Test Integer arithmetic Mult operation") {
+    val module = ScalaParser.parseResource("stmts/tc_IntegerMultOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
   
   // Mult test between reals
   test("Test Real Mult operation") {

--- a/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
+++ b/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
@@ -1388,4 +1388,46 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
 
     assert(arrayAssigment.accept(visitor) == List())
   }
+
+  //Arithmethic Operations
+
+  
+  //Sum Operations
+  
+  test("Test Integer arithmetic Sum operation") {
+    val module = ScalaParser.parseResource("stmts/tc_IntegerSumOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
+
+  //Sum tests with reals
+  //Sum tests with reals and integers
+
+  //Sub Operations
+
+  test("Test Integer arithmetic Sub operation") {
+    val module = ScalaParser.parseResource("stmts/tc_IntegerSubOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
+  //Sub tests between reals
+  //Sub tests between reals and integers
+
+  //Div
+  //Div tests between integers
+  //Div tests between integers
+  //Div tests between reals
+  
+  //Mult
+  //Mult tests between reals
+  //Mult tests between integers and reals
+  //Mult tests between integers and reals
+  
+
 }

--- a/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
+++ b/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
@@ -1389,11 +1389,9 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     assert(arrayAssigment.accept(visitor) == List())
   }
 
-  //Arithmethic Operations
+  // Arithmethic Operations
 
-  
-  //Sum Operations
-  
+  // Sum test with integers
   test("Test Integer arithmetic Sum operation") {
     val module = ScalaParser.parseResource("stmts/tc_IntegerSumOperation.oberon")
     val visitor = new TypeChecker()
@@ -1403,11 +1401,26 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
   }
 
 
-  //Sum tests with reals
-  //Sum tests with reals and integers
+  // Sum test with reals
+  test("Test Real Sum operation") {
+    val module = ScalaParser.parseResource("stmts/tc_RealSumOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
 
-  //Sub Operations
+    assert(errors.size == 0)
+  }
 
+  // Sum test with reals and integers
+  test("Test Real and Integer arithmetic Sum operation") {
+    val module = ScalaParser.parseResource("stmts/tc_RealIntegerSumOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+  
+
+  // Sub teste with integers
   test("Test Integer arithmetic Sub operation") {
     val module = ScalaParser.parseResource("stmts/tc_IntegerSubOperation.oberon")
     val visitor = new TypeChecker()
@@ -1416,18 +1429,57 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     assert(errors.size == 0)
   }
 
-  //Sub tests between reals
-  //Sub tests between reals and integers
+  // Sub test between reals
+  test("Test Real Sub operation") {
+    val module = ScalaParser.parseResource("stmts/tc_RealSubOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
 
-  //Div
-  //Div tests between integers
-  //Div tests between integers
-  //Div tests between reals
-  
-  //Mult
-  //Mult tests between reals
-  //Mult tests between integers and reals
-  //Mult tests between integers and reals
-  
+    assert(errors.size == 0)
+  }
 
+  // Sub test between reals and integers
+  test("Test Real and Integer arithmetic Sub operation") {
+    val module = ScalaParser.parseResource("stmts/tc_RealIntegerSubOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
+  // Div test between integers
+  test("Test Integer arithmetic Div operation") {
+    val module = ScalaParser.parseResource("stmts/tc_IntegerDivOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
+  // Div test between reals
+  test("Test Real Div operation") {
+    val module = ScalaParser.parseResource("stmts/tc_RealDivOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+  
+  // Mult test between reals
+  test("Test Real Mult operation") {
+    val module = ScalaParser.parseResource("stmts/tc_RealMultOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
+
+  // Mult test between integers and reals
+  test("Test Real and Integer arithmetic Mult operation") {
+    val module = ScalaParser.parseResource("stmts/tc_RealIntegerMultOperation.oberon")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+
+    assert(errors.size == 0)
+  }
 }


### PR DESCRIPTION
### Porque esse merge é necessário
Ao revisarmos e aprendemos como o Type Checker funciona, nos deparamos com algumas problematicas.

- A implementação de verificação de typos para integers estava funcionando bem, mas estava faltando para o tipo record.
- Havia uma pequena variedade de casos de teste, o que é essencial para projetos de progamação dessa magnitude.


### O que esse merge faz

Implementa dentro do modulo TypeChecker.scala uma função que possibilita a verificação de numbers do typo record, o que não era possível  antes da implementação.

Além disso, adiciona uma série de casos de testes relacionados a pointers, records e a operações aritiméticas.

Mais informações podem ser encontradas na documentação do Merge no notion:
https://www.notion.so/Documenta-o-dos-testes-7262f06c542f4ebdadf2abcfdb34a12e
