### PR TITLE
Fixing the precedence of the 'MOD' operator

### DIFF
--- a/src/main/antlr4/Oberon.g4
+++ b/src/main/antlr4/Oberon.g4
@@ -74,8 +74,8 @@ expression
  | name = Id '^'                                                                          #PointerAccess
  | '~' exp = expression                                                                   #NotExpression
  | left = expression opr = ('=' | '#' | '<' | '<=' | '>' | '>=')  right = expression      #RelExpression
- | left = expression opr = ('MOD' | '*' | '/' | '&&') right = expression                          #MultExpression
- | left = expression opr = ('+' | '-' | '||') right = expression                  #AddExpression
+ | left = expression opr = ('MOD' | '*' | '/' | '&&') right = expression                  #MultExpression
+ | left = expression opr = ('+' | '-' | '||') right = expression                          #AddExpression
  ;
 
 qualifiedName

--- a/src/main/antlr4/Oberon.g4
+++ b/src/main/antlr4/Oberon.g4
@@ -74,8 +74,8 @@ expression
  | name = Id '^'                                                                          #PointerAccess
  | '~' exp = expression                                                                   #NotExpression
  | left = expression opr = ('=' | '#' | '<' | '<=' | '>' | '>=')  right = expression      #RelExpression
- | left = expression opr = ('*' | '/' | '&&') right = expression                          #MultExpression
- | left = expression opr = ('MOD' | '+' | '-' | '||') right = expression                  #AddExpression
+ | left = expression opr = ('MOD' | '*' | '/' | '&&') right = expression                          #MultExpression
+ | left = expression opr = ('+' | '-' | '||') right = expression                  #AddExpression
  ;
 
 qualifiedName

--- a/src/test/resources/aritmetic/aritmetic38.oberon
+++ b/src/test/resources/aritmetic/aritmetic38.oberon
@@ -1,0 +1,6 @@
+MODULE Aritmetic38;
+
+CONST
+  x = 6 + 5 MOD 4;
+
+END Aritmetic38.

--- a/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/parser/ParserTest.scala
@@ -1815,6 +1815,15 @@ class ParserTestSuite extends AbstractTestSuite {
     assert(userProcedure.stmt.asInstanceOf[SequenceStmt].stmts.length == 3)
   }
 
+  test("Testing the oberon aritmetic38 code module. This module demonstrates the high precedence of MOD") {
+    val module = ScalaParser.parseResource("aritmetic/aritmetic38.oberon")
+
+    assert(module.name == "Aritmetic38")
+    assert(module.constants.size == 1)
+    assert(module.constants.head == 
+      Constant("x", AddExpression(IntValue(6), ModExpression(IntValue(5), IntValue(4)))))
+  }
+
   test("Testing module B oberon import module feature. Import one module") {
     val moduleB = ScalaParser.parseResource("imports/B.oberon")
 


### PR DESCRIPTION
The ANTLR file describing the Oberon grammar was written in such a way that the 'MOD' operator had the same precedence as the '+' operator, when it should have the precedence of the '*' operator instead. This pull request fixes this issue.

In addition to changing the parser code, a test was added that checks whether the 'MOD' operator is now behaving correctly or not.