### PR TITLE
Refactored Main.scala

### DIFF
--- a/src/main/scala/br/unb/cic/oberon/Main.scala
+++ b/src/main/scala/br/unb/cic/oberon/Main.scala
@@ -8,181 +8,86 @@ import br.unb.cic.oberon.repl.REPL
 import org.rogach.scallop._
 import org.rogach.scallop.exceptions
 
-import java.io.FileOutputStream
-import java.nio.file.{Files, Paths}
+import java.nio.file.{Files, Paths, Path}
 import java.util.Base64
 
-
-/**
- * This is the configuration of the CLI (command line interface),
- * using the Scallop library. For more details visit the library
- * website: https://github.com/scallop/scallop
- *
- * @param arguments The string list with the command line arguments.
- */
-class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
-  version("Oberon 0.1.1-SNAPSHOT")
-  banner("""Compiler and interpreter for Oberon""".stripMargin)
-
-  val tc = opt[String](name = "typeChecker", short = 't', descr = "Check if a oberon program is well typed", argName = "Oberon program path")
-  val interpreter = opt[String](name = "interpreter", short = 'i', descr = "Interprets an Oberon program", argName = "Oberon program path" )
-  val compile = opt[List[String]](name = "compile", short = 'c', descr = "Compiles an Oberon program to C", argName = "Oberon program path> <C program output path")
-  val jvmCompile = opt[List[String]](name = "compileJVM",  descr = "Compiles an Oberon program to JVM", argName = "Oberon program path> <JVM program output path")
-
-  val repl = opt[Boolean](name = "REPL", short = 'R', descr = "Run Oberon REPL")
-
-  requireOne(tc, interpreter, compile, jvmCompile, repl)
-
-  override def onError(e: Throwable): Unit = e match {
-    case exceptions.Help("") => printHelp()
-    case exceptions.Version => println("Oberon 0.1.1-SNAPSHOT")
-    case other => println(other.getMessage)
-  }
-
-  verify()
-
-}
-
-/**
- * The Main program of our implementation, using a Scala
- * object. In this case, we opted for inheriting from the
- * App trait.
- *
- * see more information here:
- *    * https://www.scala-lang.org/documentation/your-first-lines-of-scala.html
- */
 object Main extends App {
 
-  /* main block of code */
-  val conf = new Conf(args)
+  object conf extends ScallopConf(args) {
+    version("Oberon 0.1.1-SNAPSHOT")
+    banner("Compiler and interpreter for Oberon")
 
-  try {
-    if (conf.tc.isSupplied) {
-      typeCheck(conf)
+    object tc extends Subcommand("typeChecker") {
+      val inputPath = opt[Path](name="in", descr = "Path of the input file", required=true)
+      validatePathExists(inputPath)
     }
-    else if (conf.interpreter.isSupplied) {
-      interpret(conf)
+    object interpreter extends Subcommand("interpreter") {
+      val inputPath = opt[Path](name="in", descr = "Path of the input file", required=true)
+      validatePathExists(inputPath)
     }
-    else if (conf.compile.isSupplied) {
-      compile(new PaigesBasedGenerator,  conf.compile.getOrElse(List()))
-    } else if (conf.jvmCompile.isSupplied) {
-      compile(JVMCodeGenerator, conf.jvmCompile.getOrElse(List()))
-    }
-    else if (conf.repl.isSupplied) {
-      runREPL()
-    }
-  }
-  catch {
-    case t: Throwable => println(t.getMessage)
-  }
-  if (conf.args.isEmpty) conf.printHelp()
+    object compile extends Subcommand("compile") {
+      val inputPath = opt[Path](name="in", descr = "Path of the input file", required=true)
+      val outputPath = opt[Path](name = "out", descr = "Path of the output file", argName = "path", required=true)
+      validatePathExists(inputPath)
 
-  /* end of the main block */
+      val backend = choice(name="backend", choices=Seq("llvm", "c", "jvm"), descr="Which backend to compile to", required=true)
+    }
+    object repl extends Subcommand("repl") {}
 
-  /**
-   * Executes the REPL (Read, Eval, Print, Loop) program
-   */
-  private def runREPL() = {
-    REPL.runREPL()
+    addSubcommand(tc)
+    addSubcommand(interpreter)
+    addSubcommand(compile)
+    addSubcommand(repl)
+    requireSubcommand()
+
+    verify()
   }
 
-  /**
-   * Executes the Oberon compiler.
-   *
-   * @param generator Either the CCodeGenerator or the JVMCodeGenerator
-   * @param config the paths to the Oberon input and output files
-   */
-  private def compile(generator: CodeGenerator, config: List[String]) = {
-    if(config.size != 2) {
-      throw new RuntimeException("Wrong number of program arguments.")
-    }
+  conf.subcommand match {
+    case Some(conf.tc) => typeCheck()
+    case Some(conf.interpreter) => interpret()
+    case Some(conf.compile) => compile()
+    case Some(conf.repl) => REPL.runREPL()
+  }
 
-    val oberonPath = Paths.get(config(0))
+  private def compile() {
+    val content = Files.readString(conf.compile.inputPath.get.get)
+    val module = ScalaParser.parse(content)
 
-    if (Files.exists(oberonPath)) {
-      val oberonContent = String.join("\n", Files.readAllLines(oberonPath))
-      val module = ScalaParser.parse(oberonContent)
-
-      val generatedCode = generator.generateCode(module)
-
-
-      if(generator == JVMCodeGenerator) {
-        val out = new FileOutputStream(createOutputFile(config(1), module.name).toFile)
-        out.write(Base64.getDecoder.decode(generatedCode))
+    conf.compile.backend.get.get match {
+      case "c" => {
+        val generatedCode = (new PaigesBasedGenerator).generateCode(module)
+        Files.writeString(conf.compile.outputPath.get.get, generatedCode)
       }
-      else {
-        val path = Paths.get(config(1))
-
-        val writer = Files.newBufferedWriter(path)
-
-        writer.write(generatedCode)
-        writer.flush()
-        writer.close()
+      case "jvm" => {
+        val generatedCode = JVMCodeGenerator.generateCode(module)
+        Files.write(conf.compile.outputPath.get.get, Base64.getDecoder.decode(generatedCode))
+      }
+      case "llvm" => {
+        Files.writeString(conf.compile.outputPath.get.get, "LLVM :)")
       }
     }
-    else {
-      println("The file '" + conf.compile() + "' does not exist")
-    }
   }
 
-  /*
-  * Creates (or override) a class file
-  * @param name name of the class file
-  * @return the relative Path to the class file.
-  */
-  def createOutputFile(path: String, name: String) = {
-    val base = Paths.get(path)
-    Files.createDirectories(base)
-    val classFile = Paths.get(path + "/" + name + ".class")
-    if(Files.exists(classFile)) {
-      Files.delete(classFile)
-    }
-    Files.createFile(classFile)
+  private def interpret() = {
+    val content = Files.readString(conf.interpreter.inputPath.get.get)
+    val module = ScalaParser.parse(content)
+
+    val interpreter = new Interpreter()
+    val result = module.accept(interpreter)
   }
 
+  private def typeCheck() = {
+    val content = Files.readString(conf.tc.inputPath.get.get)
+    val module = ScalaParser.parse(content)
 
-  /**
-   * Executes the Oberon interpreter.
-   *
-   * @param conf the CLI configuration
-   */
-  private def interpret(conf: Conf) = {
-    val path = Paths.get(conf.interpreter())
-
-    if (Files.exists(path)) {
-      val interpreter = new Interpreter()
-
-      val content = String.join("\n", Files.readAllLines(path))
-      val module = ScalaParser.parse(content)
-
-      val result = module.accept(interpreter)
-    }
-    else {
-      println("The file '" + conf.interpreter() + "' does not exist")
-    }
-  }
-
-  /**
-   * Executes the type checker
-   *
-   * @param conf the CLI configuration
-   */
-  private def typeCheck(conf: Conf) = {
-    val path = Paths.get(conf.tc())
-    if (Files.exists(path)) {
-      val content = String.join("\n", Files.readAllLines(path))
-
-      val module = ScalaParser.parse(content)
-      val visitor = new TypeChecker()
-
-      val errors = visitor.visit(module)
-      errors.foreach(v => if (v._2 != "None") println(v))
-      if (errors.isEmpty) println("The code is correctly typed")
-      else println("Type error detected")
-    }
-    else {
-      println("The file '" + conf.tc() + "' does not exist")
+    val visitor = new TypeChecker()
+    val errors = visitor.visit(module)
+    if (errors.isEmpty) {
+      println("The code is correctly typed")
+    } else {
+      println("Type errors detected:")
+      errors.filter(v => (v._2 != "None")).foreach(v => println(v))
     }
   }
 }
-

--- a/src/main/scala/br/unb/cic/oberon/Main.scala
+++ b/src/main/scala/br/unb/cic/oberon/Main.scala
@@ -18,19 +18,19 @@ object Main extends App {
     banner("Compiler and interpreter for Oberon")
 
     object tc extends Subcommand("typeChecker") {
-      val inputPath = opt[Path](name="in", descr = "Path of the input file", required=true)
+      val inputPath = opt[Path](name="in", descr = "Path of the input file", argName = "path", required=true)
       validatePathExists(inputPath)
     }
     object interpreter extends Subcommand("interpreter") {
-      val inputPath = opt[Path](name="in", descr = "Path of the input file", required=true)
+      val inputPath = opt[Path](name="in", descr = "Path of the input file", argName = "path", required=true)
       validatePathExists(inputPath)
     }
     object compile extends Subcommand("compile") {
-      val inputPath = opt[Path](name="in", descr = "Path of the input file", required=true)
+      val inputPath = opt[Path](name="in", descr = "Path of the input file", argName = "path", required=true)
       val outputPath = opt[Path](name = "out", descr = "Path of the output file", argName = "path", required=true)
       validatePathExists(inputPath)
 
-      val backend = choice(name="backend", choices=Seq("llvm", "c", "jvm"), descr="Which backend to compile to", required=true)
+      val backend = choice(name="backend", choices=Seq("llvm", "c", "jvm"), default=Some("c"), descr="Which backend to compile to", argName="backend")
     }
     object repl extends Subcommand("repl") {}
 


### PR DESCRIPTION
Refactored Main.Scala using Scallop "subcommands" instead of "options" for everything, which is probably the intended abstraction for the usecase. Also made use of some other features from the Scallop library, such as opt[Path] and validatePathExists(), which makes it so we don't have to check if input files exist ourselves.

The JVM compilation behavior is different from how it was before. I don't know how exactly it is supposed to be.

Usage:
`java -jar oberon.jar compile --input test.oberon --output test.c --backend c`
`java -jar oberon.jar compile -i test.oberon -o test.c -b c`
`java -jar oberon.jar compile -i test.oberon -o test.llvm -b llvm`
`java -jar oberon.jar interpreter -i test.oberon`
`java -jar oberon.jar repl`