### PR TITLE
Fix all compiler warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ organization := "br.unb.cic"
 version := "0.1.1"
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.0.0"
+scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 // githubOwner := "UnBCIC-TP2"
 // githubRepository := "Oberon-Scala"

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ organization := "br.unb.cic"
 version := "0.1.1"
 
 libraryDependencies += "org.typelevel" %% "cats-core" % "2.0.0"
-scalacOptions ++= Seq("-unchecked", "-deprecation")
 
 // githubOwner := "UnBCIC-TP2"
 // githubRepository := "Oberon-Scala"

--- a/src/main/scala/br/unb/cic/oberon/Main.scala
+++ b/src/main/scala/br/unb/cic/oberon/Main.scala
@@ -54,7 +54,7 @@ class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
 object Main extends App {
 
   /* main block of code */
-  val conf = new Conf(args)
+  val conf = new Conf(args.toIndexedSeq)
 
   try {
     if (conf.tc.isSupplied) {

--- a/src/main/scala/br/unb/cic/oberon/ast/OberonModule.scala
+++ b/src/main/scala/br/unb/cic/oberon/ast/OberonModule.scala
@@ -283,6 +283,6 @@ case class REPLConstant(constants: Constant) extends REPL
 case class REPLUserTypeDeclaration(userTypes: UserDefinedType) extends REPL
 
 object ValueConversion {
-  implicit def intValue2RealValue(intValue: IntValue): RealValue = RealValue(intValue.value)
-  implicit def charValue2IntValue(charValue: CharValue): IntValue = IntValue(charValue.value)
+  def intValue2RealValue(intValue: IntValue): RealValue = RealValue(intValue.value.toDouble)
+  def charValue2IntValue(charValue: CharValue): IntValue = IntValue(charValue.value.toInt)
 }

--- a/src/main/scala/br/unb/cic/oberon/ast/OberonModule.scala
+++ b/src/main/scala/br/unb/cic/oberon/ast/OberonModule.scala
@@ -157,8 +157,11 @@ case class RealValue(value: Double) extends Value with Number {
 case class CharValue(value: Char) extends Value { type T = Char }
 case class StringValue(value: String) extends Value { type T = String }
 case class BoolValue(value: Boolean) extends Value { type T = Boolean }
+case object NullValue extends Value {
+	type T = Unit
+	def value: T = ()
+}
 
-case object NullValue extends Expression
 case class Location(loc: Int) extends Expression
 case class Brackets(exp: Expression) extends Expression
 case class ArrayValue(value: ListBuffer[Expression], arrayType: ArrayType) extends Value { type T = ListBuffer[Expression] }

--- a/src/main/scala/br/unb/cic/oberon/ast/OberonModule.scala
+++ b/src/main/scala/br/unb/cic/oberon/ast/OberonModule.scala
@@ -44,7 +44,7 @@ case class Procedure(name: String,
 }
 
 /* formal argument definition */
-trait FormalArg{
+sealed trait FormalArg{
   def accept(v: OberonVisitor): v.T = v.visit(this)
   def argumentType: Type
   def name: String

--- a/src/main/scala/br/unb/cic/oberon/codegen/CCodeGenerator.scala
+++ b/src/main/scala/br/unb/cic/oberon/codegen/CCodeGenerator.scala
@@ -47,10 +47,10 @@ case class PaigesBasedGenerator() extends CCodeGenerator {
     }
 
     val args = procedure.args.map {
-      case parameterByValue =>
-        text(convertVariable(parameterByValue.name, parameterByValue.argumentType, userTypes, isArgument = true))
-      case parameterByReference =>
-        text(convertVariable(parameterByReference.name, parameterByReference.argumentType, userTypes, isArgument = true))
+      case ParameterByValue(name, argumentType) =>
+        text(convertVariable(name, argumentType, userTypes, isArgument = true))
+      case ParameterByReference(name, argumentType) =>
+        text(convertVariable(name, argumentType, userTypes, isArgument = true))
     }
 
     val procedureDeclarations = declareVars(procedure.variables, List(), indentSize)

--- a/src/main/scala/br/unb/cic/oberon/codegen/CCodeGenerator.scala
+++ b/src/main/scala/br/unb/cic/oberon/codegen/CCodeGenerator.scala
@@ -115,6 +115,7 @@ case class PaigesBasedGenerator() extends CCodeGenerator {
             declareVars(variables, userTypes, indentSize) +
             textln("};") +
           textln(s"typedef struct ${structName}_struct $structName;")
+		case _ => throw new Exception("Non-exhaustive match in case statement.")
       })
     }
     generatedDoc
@@ -140,7 +141,9 @@ case class PaigesBasedGenerator() extends CCodeGenerator {
         val userType = stringToType(name, userTypes)
         userType match {
           case RecordType(_) => s"struct $name"
+		  case _ => throw new Exception("Non-exhaustive match in case statement.")
         }
+	case _ => throw new Exception("Non-exhaustive match in case statement.")
     }
   }
 
@@ -221,6 +224,7 @@ case class PaigesBasedGenerator() extends CCodeGenerator {
             val structName = genExp(record)
             val value = genExp(exp)
             textln(indent, s"$structName.$atrib = $value;")
+		  case _ => throw new Exception("Non-exhaustive match in case statement.")
         }
 
       case ExitStmt() =>

--- a/src/main/scala/br/unb/cic/oberon/codegen/JVMCodeGenerator.scala
+++ b/src/main/scala/br/unb/cic/oberon/codegen/JVMCodeGenerator.scala
@@ -41,6 +41,7 @@ object JVMCodeGenerator extends CodeGenerator {
       v.variableType match {
         case IntegerType =>  cw.visitField(ACC_PUBLIC, v.name, "I", null, Integer.valueOf(0)).visitEnd()
         case BooleanType => cw.visitField(ACC_PUBLIC, v.name, "Z", null, false).visitEnd()
+		case _ => throw new Exception("Non-exhaustive match in case statement.")
       }
     )
   }

--- a/src/main/scala/br/unb/cic/oberon/interpreter/Interpreter.scala
+++ b/src/main/scala/br/unb/cic/oberon/interpreter/Interpreter.scala
@@ -209,6 +209,7 @@ class Interpreter extends OberonVisitorAdapter {
       case (ParameterByReference(name, _), Some(location: Location)) => env.setParameterReference(name, location)
       case (ParameterByReference(_, _), _) => throw new RuntimeException
       case (ParameterByValue(name, _), exp: Expression) => env.setLocalVariable(name, exp)
+	  case _ => throw new RuntimeException
     })
     procedure.constants.foreach(c => env.setLocalVariable(c.name, c.exp))
     procedure.variables.foreach(v => env.setLocalVariable(v.name, Undef()))

--- a/src/main/scala/br/unb/cic/oberon/interpreter/Interpreter.scala
+++ b/src/main/scala/br/unb/cic/oberon/interpreter/Interpreter.scala
@@ -363,5 +363,5 @@ class EvalExpressionVisitor(val interpreter: Interpreter) extends OberonVisitorA
 class NullPrintStream extends PrintStream(new NullByteArrayOutputStream) {}
 
 class NullByteArrayOutputStream extends ByteArrayOutputStream {
-  override def writeTo(o: OutputStream) {}
+  override def writeTo(o: OutputStream): Unit = ()
 }

--- a/src/main/scala/br/unb/cic/oberon/parser/ParserCombinator.scala
+++ b/src/main/scala/br/unb/cic/oberon/parser/ParserCombinator.scala
@@ -145,6 +145,7 @@ trait StatementParser extends ExpressionParser {
         { case a ~ b => List(a) ++ b } ^^ {
             case a :: Nil => a
             case a :: b => SequenceStmt(a :: b)
+			case Nil => SequenceStmt(Nil)
         }
     );
 }

--- a/src/main/scala/br/unb/cic/oberon/parser/ParserCombinator.scala
+++ b/src/main/scala/br/unb/cic/oberon/parser/ParserCombinator.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable.Map
 
 trait ParsersUtil extends JavaTokenParsers {
     // Encapsulator aggregator function
-    def aggregator[T](r: T ~ List[T => T]): T = { r match { case a ~ b => (a /: b)((acc,f) => f(acc)) } }
+    def aggregator[T](r: T ~ List[T => T]): T = { r match { case a ~ b => (b.foldLeft(a))((acc,f) => f(acc)) } }
 
     // List Helper Function
     def listOpt[T](parser: Parser[List[T]]): Parser[List[T]] = opt(parser) ^^ {

--- a/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
+++ b/src/main/scala/br/unb/cic/oberon/parser/ScalaParser.scala
@@ -43,7 +43,7 @@ object ScalaParser {
   }
 
   private def createOberonParser(input: String) = {
-    val lexer = new OberonLexer(new ANTLRInputStream(input))
+    val lexer = new OberonLexer(CharStreams.fromString(input))
     lexer.removeErrorListeners
     lexer.addErrorListener(OberonErrorListener)
 
@@ -429,12 +429,13 @@ class ParserVisitor {
     /*
      * The "ugly", though necessary code for visiting binary expressions.
      */
-    private def visitBinExpression(left: OberonParser.ExpressionContext, right: OberonParser.ExpressionContext, constructor: (Expression, Expression) => Expression) {
+    private def visitBinExpression(left: OberonParser.ExpressionContext, right: OberonParser.ExpressionContext, constructor: (Expression, Expression) => Expression): Unit = {
       left.accept(this) // first visit the left hand side of an expression.
       val lhs = exp // assign the result to the value lhs
       right.accept(this) // second, visit the right hand side of an expression
       val rhs = exp // assign the result to the value rhs
       exp = constructor(lhs, rhs) // assign the result to exp, using the 'constructor' to set the actual expression
+	  ()
     }
   }
 

--- a/src/main/scala/br/unb/cic/oberon/repl/OberonEngine.scala
+++ b/src/main/scala/br/unb/cic/oberon/repl/OberonEngine.scala
@@ -101,7 +101,7 @@ class OberonEngine extends ScriptEngine {
       case i: Integer => i.toString
       case b: lang.Boolean => b.toString
       case v: Value => v.value.toString
-      case m: util.Map[Object, Object] => "{}"
+      case m: util.Map[_, _] => "{}"
       case _ =>
         if (obj == null) "null"
         else s"toString not implemented for $obj (${obj.getClass})"

--- a/src/main/scala/br/unb/cic/oberon/stdlib/StandardLibrary.scala
+++ b/src/main/scala/br/unb/cic/oberon/stdlib/StandardLibrary.scala
@@ -213,7 +213,7 @@ class StandardLibrary[T](env: Environment[T]) {
   }*/
 
   def using[A <: {def close(): Unit}, B](param: A)(f: A => B): B =
-    try { f(param) } finally { param.close() }
+    try { f(param) } finally { import scala.language.reflectiveCalls; param.close() }
 
   def appendF(path:String, content:String) =
     using (new FileWriter(path, true)){


### PR DESCRIPTION
Fixed every warning given during compilation. The warnings fixed were due to:

- Several non-exhaustive case statements
- Implicit type conversion
- Non-variable type argument was unchecked in OberonEngine.scala, since it was eliminated by erasure
- Use of deprecated `/:` operator
- Use of deprecated `ANTLRInputStream`

Also, the object `NullValue` was modified so that it inherits from `Value` instead of `Expression`. This change should allow the interpreter environment to be an `Environment[Value]` instead of an `Environment[Expression]`. Every test still succeeded.