### PR TITLE
Grupo 1: Refatoração do módulo CoreTransformer

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.4.2

--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -96,40 +96,35 @@ class CoreVisitor() extends OberonVisitorAdapter {
         throw new IllegalArgumentException("elsifStmts cannot be empty.")
     }
 
-private def transformProcedureListStatement(listProcedures: List[Procedure], proceduresCore: ListBuffer[Procedure] = new ListBuffer[Procedure]): List[Procedure] = {
-    for (procedure <- listProcedures){
-      proceduresCore += Procedure(
-        name = procedure.name,
-        args = procedure.args,
-        returnType = procedure.returnType,
-        constants = procedure.constants,
-        variables = procedure.variables,
-        stmt = procedure.stmt.accept(this))
+  private def transformProcedureStatement(procedure: Procedure): Procedure = {
+      Procedure(
+      name = procedure.name,
+      args = procedure.args,
+      returnType = procedure.returnType,
+      constants = procedure.constants,
+      variables = procedure.variables,
+      stmt = procedure.stmt.accept(this))
     }
-    proceduresCore.toList
-  }
 
   def flatSequenceOfStatements(stmts: List[Statement]): List[Statement] = stmts.flatMap {
     case SequenceStmt(ss) => flatSequenceOfStatements(ss)
     case s => List(s)
   }
 
-
   def transformModule(module: OberonModule): OberonModule = {
     // É possível remover essa val?
     val stmtcore = module.stmt.get.accept(this)
 
-    OberonModule(
+     OberonModule(
       name = module.name,
       submodules = module.submodules,
       userTypes = module.userTypes,
       constants = module.constants,
       variables = module.variables ++ addedVariables,
-      procedures = transformProcedureListStatement(module.procedures),
+      procedures = module.procedures.map(transformProcedureStatement(_)),
       stmt = Some(stmtcore)
     )
   }
-
 }
 
 object CoreChecker {

--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -161,13 +161,12 @@ class CoreVisitor() extends OberonVisitorAdapter {
 
 }
 
-object CoreChecker extends OberonVisitorAdapter {
-  override type T = Unit
-  override def stmtCheker(stmt: Statement): Boolean = {
+object CoreChecker {
+  
+  def stmtCheker(stmt: Statement): Boolean = {
 
     stmt match {
-      // Analisar se todos os stmts sao do tipo core
-      case SequenceStmt(_) => true // TODO: remover "true" e descomentar transformListStmts(stmts) END TODO 
+      case SequenceStmt(stmts) => stmts.map(s => stmtCheker(s)).foldLeft(true)(_ && _)
       case LoopStmt(_) => false
       case RepeatUntilStmt(_, _) =>  false
       case ForStmt(_, _, _) => false
@@ -178,7 +177,7 @@ object CoreChecker extends OberonVisitorAdapter {
 
       // Outros casos com SequenceStmt
       case WhileStmt(condition, whileStmt) => true // TODO: remover "true" e descomentar whileStmt.accept(this)
-      case IfElseStmt(condition, thenStmt, elseStmt) => thenStmt.accept(this);
+      case IfElseStmt(condition, thenStmt, elseStmt) => true // thenStmt.accept(this);
       // O que esta acontecendo aqui???
       elseStmt match {
         case Some(f) => Some(elseStmt.get.accept((this)))

--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -34,13 +34,7 @@ class CoreVisitor() extends OberonVisitorAdapter {
     case _ => stmt
   }
 
-  private var nextCaseId = 0
-
-  private def getNextCaseId(): Int = {
-    val returnId = nextCaseId
-    nextCaseId += 1
-    returnId
-  }
+  private val caseIdGenerator: Iterator[Int] = Iterator.from(0)
 
   private def transformCase(exp: Expression, cases: List[CaseAlternative], elseStmt: Option[Statement]): Statement = {
     val coreElseStmt = elseStmt.map(_.accept(this))
@@ -49,7 +43,7 @@ class CoreVisitor() extends OberonVisitorAdapter {
 
     val caseExpressionId = exp match {
       case VarExpression(name) => name
-      case _ => f"case_exp#${getNextCaseId}"
+      case _ => f"case_exp#${caseIdGenerator.next()}"
     }
     val caseExpressionEvaluation = AssignmentStmt(VarAssignment(caseExpressionId), exp)
 

--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -117,12 +117,11 @@ private def transformProcedureListStatement(listProcedures: List[Procedure], pro
     proceduresCore.toList
   }
 
-  def flatSequenceOfStatements(stmts: List[Statement]): List[Statement] =
-    stmts match {
-      case SequenceStmt(ss) :: rest => flatSequenceOfStatements(ss) ++ flatSequenceOfStatements(rest)
-      case s :: rest => s :: flatSequenceOfStatements(rest)
-      case Nil => List()
-    }
+  def flatSequenceOfStatements(stmts: List[Statement]): List[Statement] = stmts.flatMap {
+    case SequenceStmt(ss) => flatSequenceOfStatements(ss)
+    case s => List(s)
+  }
+
 
   def transformModule(module: OberonModule): OberonModule = {
     // É possível remover essa val?

--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -86,17 +86,15 @@ class CoreVisitor() extends OberonVisitorAdapter {
     }
   }
 
-  private def transformElsif (elsifStmts: List[ElseIfStmt], elseStmt: Option[Statement]): Statement = {
-    val coreElseStmt = elseStmt.map(_.accept(this))
-    val currentElsif = elsifStmts.head
-
-    if (elsifStmts.tail.isEmpty) {
-      IfElseStmt(currentElsif.condition, currentElsif.thenStmt.accept(this), coreElseStmt)
-    } else {
-      val nextElsif = Some(transformElsif(elsifStmts.tail, coreElseStmt))
-      IfElseStmt(currentElsif.condition, currentElsif.thenStmt.accept(this), nextElsif)
+  private def transformElsif(elsifStmts: List[ElseIfStmt], elseStmt: Option[Statement]): Statement =
+    elsifStmts match {
+      case currentElsif :: Nil =>
+        IfElseStmt(currentElsif.condition, currentElsif.thenStmt.accept(this), elseStmt.map(_.accept(this)))
+      case currentElsif :: tail =>
+        IfElseStmt(currentElsif.condition, currentElsif.thenStmt.accept(this), Some(transformElsif(tail, elseStmt.map(_.accept(this)))))
+      case Nil =>
+        throw new IllegalArgumentException("elsifStmts cannot be empty.")
     }
-  }
 
 private def transformProcedureListStatement(listProcedures: List[Procedure], proceduresCore: ListBuffer[Procedure] = new ListBuffer[Procedure]): List[Procedure] = {
     for (procedure <- listProcedures){

--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -163,13 +163,13 @@ class CoreVisitor() extends OberonVisitorAdapter {
 
 object CoreChecker {
   
-  def stmtCheker(stmt: Statement): Boolean = {
+  def stmtCheck(stmt: Statement): Boolean = {
     stmt match {
-      case SequenceStmt(stmts) => stmts.map(s => stmtCheker(s)).foldLeft(true)(_ && _)
-      case WhileStmt(_, whileStmt) => this.stmtCheker(whileStmt)
-      case IfElseStmt(_, thenStmt, elseStmt) => this.stmtCheker(thenStmt)
+      case SequenceStmt(stmts) => stmts.map(s => stmtCheck(s)).foldLeft(true)(_ && _)
+      case WhileStmt(_, whileStmt) => this.stmtCheck(whileStmt)
+      case IfElseStmt(_, thenStmt, elseStmt) => this.stmtCheck(thenStmt)
       elseStmt match {
-        case Some(f) => this.stmtCheker(f)
+        case Some(f) => this.stmtCheck(f)
         case None => false
       }
 

--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -166,19 +166,23 @@ object CoreChecker {
   def stmtCheck(stmt: Statement): Boolean = {
     stmt match {
       case SequenceStmt(stmts) => stmts.map(s => stmtCheck(s)).foldLeft(true)(_ && _)
-      case WhileStmt(_, whileStmt) => this.stmtCheck(whileStmt)
-      case IfElseStmt(_, thenStmt, elseStmt) => this.stmtCheck(thenStmt)
-      elseStmt match {
-        case Some(f) => this.stmtCheck(f)
-        case None => false
-      }
 
-      case _ => false
+      // Laços
+      case LoopStmt(stmt) => false
+      case RepeatUntilStmt(condition, stmt) => false
+      case ForStmt(initStmt, condition, block) => false
+      case WhileStmt(_, whileStmt) => stmtCheck(whileStmt)
+      
+      // Condicionais
+      case CaseStmt(exp, cases, elseStmt) => false  
+      case IfElseIfStmt (condition, thenStmt, elsifStmt, elseStmt) => false
+      case IfElseStmt(_, thenStmt, Some(elseStmt)) => stmtCheck(thenStmt) && stmtCheck(elseStmt)
+      
+      case _ => true
     }
   }
 
   def isModuleCore(module: OberonModule): Boolean = {
-    //TODO: checar se o module do tipo OberonModule é core
-    true
+    stmtCheck(module.stmt.get) && module.procedures.map(p => stmtCheck(p.stmt)).foldLeft(true)(_ && _)
   }
 }

--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -162,60 +162,57 @@ class CoreVisitor() extends OberonVisitorAdapter {
 }
 
 object CoreChecker extends OberonVisitorAdapter {
-  private var isCore = true
-
   override type T = Unit
-
-  override def visit(stmt: Statement): Unit = {
-
-    if (!isCore) {
-      return
-    }
+  override def stmtCheker(stmt: Statement): Boolean = {
 
     stmt match {
-      case SequenceStmt(stmts) => transformListStmts(stmts)
-      case LoopStmt(stmt) => isCore = false
-      case RepeatUntilStmt(condition, stmt) => isCore = false
-      case ForStmt(initStmt, condition, block) => isCore = false
+      // Analisar se todos os stmts sao do tipo core
+      case SequenceStmt(_) => true // TODO: remover "true" e descomentar transformListStmts(stmts) END TODO 
+      case LoopStmt(_) => false
+      case RepeatUntilStmt(_, _) =>  false
+      case ForStmt(_, _, _) => false
 
       // Condicionais
-      case IfElseIfStmt (condition, thenStmt, elsifStmt, elseStmt) => isCore = false
-      case CaseStmt(exp, cases, elseStmt) => isCore = false
+      case IfElseIfStmt (_, _, _, _) => false
+      case CaseStmt(_, _, _) => false
 
       // Outros casos com SequenceStmt
-      case WhileStmt(condition, whileStmt) => whileStmt.accept(this)
+      case WhileStmt(condition, whileStmt) => true // TODO: remover "true" e descomentar whileStmt.accept(this)
       case IfElseStmt(condition, thenStmt, elseStmt) => thenStmt.accept(this);
-        elseStmt match {
-          case Some(f) => Some(elseStmt.get.accept((this)))
-          case None => ()
-        }
+      // O que esta acontecendo aqui???
+      elseStmt match {
+        case Some(f) => Some(elseStmt.get.accept((this)))
+        case None => false
+      }
 
-      case _ => ()
+      case _ => true // Caso base, existem varios false... Podemos usar o match somente dos casos que sao possivelmente true, restante cai no base.
     }
   }
 
-  private def transformListStmts(stmtsList: List[Statement], stmtsCore: ListBuffer[Statement] = new ListBuffer[Statement]): Unit = {
-    if (stmtsList.nonEmpty){
-      stmtsList.head.accept(this);
-      transformListStmts(stmtsList.tail)
-    }
-  }
+  // TODO: Apagar depois que resolver os cases ali em cima
+  // private def transformListStmts(stmtsList: List[Statement], stmtsCore: ListBuffer[Statement] = new ListBuffer[Statement]): Unit = {
+  //   if (stmtsList.nonEmpty){
+  //     stmtsList.head.accept(this);
+  //     transformListStmts(stmtsList.tail)
+  //   }
+  // }
 
+  // Nao faco ideia do que esta acontecendo aqui
   private def checkProcedureStmts(listProcedures: List[Procedure]): Unit = {
     for (procedure <- listProcedures){
       procedure.stmt.accept(this)
     }
   }
 
-  def isModuleCore(module: OberonModule): Boolean = {
-    isCore = true
-    module.stmt.get.accept(this)
-    if (!isCore){
-      isCore
-    }
-    else{
-      module.procedures.foreach{x : Procedure => x.stmt.accept(this)}
-      isCore
-    }
-  }
+  // TODO: Apagar depois que resolver os testes de se alguma coisa for core
+  // def isModuleCore(module: OberonModule): Boolean = {
+  //   module.stmt.get.accept(this)
+  //   if (!isCore){
+  //     true
+  //   }
+  //   else{
+  //     module.procedures.foreach{x : Procedure => x.stmt.accept(this)}
+  //     true
+  //   }
+  // }
 }

--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -164,54 +164,21 @@ class CoreVisitor() extends OberonVisitorAdapter {
 object CoreChecker {
   
   def stmtCheker(stmt: Statement): Boolean = {
-
     stmt match {
       case SequenceStmt(stmts) => stmts.map(s => stmtCheker(s)).foldLeft(true)(_ && _)
-      case LoopStmt(_) => false
-      case RepeatUntilStmt(_, _) =>  false
-      case ForStmt(_, _, _) => false
-
-      // Condicionais
-      case IfElseIfStmt (_, _, _, _) => false
-      case CaseStmt(_, _, _) => false
-
-      // Outros casos com SequenceStmt
-      case WhileStmt(condition, whileStmt) => true // TODO: remover "true" e descomentar whileStmt.accept(this)
-      case IfElseStmt(condition, thenStmt, elseStmt) => true // thenStmt.accept(this);
-      // O que esta acontecendo aqui???
+      case WhileStmt(_, whileStmt) => this.stmtCheker(whileStmt)
+      case IfElseStmt(_, thenStmt, elseStmt) => this.stmtCheker(thenStmt)
       elseStmt match {
-        case Some(f) => Some(elseStmt.get.accept((this)))
+        case Some(f) => this.stmtCheker(f)
         case None => false
       }
 
-      case _ => true // Caso base, existem varios false... Podemos usar o match somente dos casos que sao possivelmente true, restante cai no base.
+      case _ => false
     }
   }
 
-  // TODO: Apagar depois que resolver os cases ali em cima
-  // private def transformListStmts(stmtsList: List[Statement], stmtsCore: ListBuffer[Statement] = new ListBuffer[Statement]): Unit = {
-  //   if (stmtsList.nonEmpty){
-  //     stmtsList.head.accept(this);
-  //     transformListStmts(stmtsList.tail)
-  //   }
-  // }
-
-  // Nao faco ideia do que esta acontecendo aqui
-  private def checkProcedureStmts(listProcedures: List[Procedure]): Unit = {
-    for (procedure <- listProcedures){
-      procedure.stmt.accept(this)
-    }
+  def isModuleCore(module: OberonModule): Boolean = {
+    //TODO: checar se o module do tipo OberonModule é core
+    true
   }
-
-  // TODO: Apagar depois que resolver os testes de se alguma coisa for core
-  // def isModuleCore(module: OberonModule): Boolean = {
-  //   module.stmt.get.accept(this)
-  //   if (!isCore){
-  //     true
-  //   }
-  //   else{
-  //     module.procedures.foreach{x : Procedure => x.stmt.accept(this)}
-  //     true
-  //   }
-  // }
 }

--- a/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
+++ b/src/main/scala/br/unb/cic/oberon/transformations/CoreTransformer.scala
@@ -17,7 +17,7 @@ class CoreVisitor() {
       WhileStmt(BoolValue(true), visit(stmt, caseIdGenerator, addedVariables))
 
     case RepeatUntilStmt(condition, stmt) =>
-      WhileStmt(BoolValue(true), SequenceStmt(List(visit(stmt, caseIdGenerator, addedVariables), visit(IfElseStmt(condition, ExitStmt(), None), caseIdGenerator, addedVariables))))
+      WhileStmt(BoolValue(true), visit(SequenceStmt(List(visit(stmt, caseIdGenerator, addedVariables), visit(IfElseStmt(condition, ExitStmt(), None), caseIdGenerator, addedVariables)))))
 
     case ForStmt(initStmt, condition, block) =>
       SequenceStmt(List(visit(initStmt, caseIdGenerator, addedVariables), WhileStmt(condition, visit(block, caseIdGenerator, addedVariables))))

--- a/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
+++ b/src/test/scala/br/unb/cic/oberon/tc/TypeCheckerTestSuite.scala
@@ -139,7 +139,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val stmt03 = ElseIfStmt(BoolValue(true), stmt02)
     val list1 = List(stmt03)
 
-    val stmt04 = IfElseIfStmt(IntValue(34), stmt01, list1, None).accept(coreTransformer)
+    val stmt04 = coreTransformer.visit(IfElseIfStmt(IntValue(34), stmt01, list1, None))
 
     assert(stmt01.accept(visitor).size == 0)
     assert(stmt02.accept(visitor).size == 0)
@@ -158,7 +158,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val stmt03 = ElseIfStmt(IntValue(70), stmt02)
     val list1 = List(stmt03)
 
-    val stmt04 = IfElseIfStmt(BoolValue(true), stmt01, list1, None).accept(coreTransformer)
+    val stmt04 = coreTransformer.visit(IfElseIfStmt(BoolValue(true), stmt01, list1, None))
 
     assert(stmt01.accept(visitor).size == 0)
     assert(stmt02.accept(visitor).size == 0)
@@ -180,7 +180,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val stmt06 = ElseIfStmt(BoolValue(false), stmt01)
     val list1 = List(stmt03, stmt04, stmt05, stmt06)
 
-    val stmt07 = IfElseIfStmt(BoolValue(true), stmt01, list1, None).accept(coreTransformer)
+    val stmt07 = coreTransformer.visit(IfElseIfStmt(BoolValue(true), stmt01, list1, None))
 
     assert(stmt01.accept(visitor).size == 0)
     assert(stmt02.accept(visitor).size == 0)
@@ -198,7 +198,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val stmt03 = ElseIfStmt(BoolValue(true), stmt02)
     val list1 = List(stmt03)
 
-    val stmt04 = IfElseIfStmt(BoolValue(true), stmt01, list1, None).accept(coreTransformer)
+    val stmt04 = coreTransformer.visit(IfElseIfStmt(BoolValue(true), stmt01, list1, None))
 
     assert(stmt01.accept(visitor).size == 0)
     assert(stmt02.accept(visitor).size == 1)
@@ -218,7 +218,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val stmt04 = ElseIfStmt(BoolValue(true), stmt02)
     val list1 = List(stmt04)
 
-    val stmt05 = IfElseIfStmt(BoolValue(true), stmt01, list1, Some(stmt03)).accept(coreTransformer)
+    val stmt05 = coreTransformer.visit(IfElseIfStmt(BoolValue(true), stmt01, list1, Some(stmt03)))
 
     assert(stmt01.accept(visitor).size == 0)
     assert(stmt02.accept(visitor).size == 0)
@@ -238,7 +238,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val stmt06 = ElseIfStmt(BoolValue(true), stmt02)
     val list1 = List(stmt04, stmt05, stmt06)
 
-    val stmt07 = IfElseIfStmt(BoolValue(true), stmt01, list1, Some(stmt03)).accept(coreTransformer)
+    val stmt07 = coreTransformer.visit(IfElseIfStmt(BoolValue(true), stmt01, list1, Some(stmt03)))
 
     assert(stmt01.accept(visitor).size == 1)
     assert(stmt02.accept(visitor).size == 1)
@@ -258,7 +258,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val stmt03 = ElseIfStmt(BoolValue(true), stmt02)
     val list1 = List(stmt03)
 
-    val stmt04 = IfElseIfStmt(BoolValue(true), stmt01, list1, None).accept(coreTransformer)
+    val stmt04 = coreTransformer.visit(IfElseIfStmt(BoolValue(true), stmt01, list1, None))
 
     assert(stmt01.accept(visitor).size == 0)
     assert(stmt02.accept(visitor).size == 0)
@@ -305,7 +305,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
 
     visitor.env.setGlobalVariable("y", IntegerType)
 
-    val stmt03 = ForStmt(stmt01, BoolValue(true), stmt02).accept(coreTransformer)
+    val stmt03 = coreTransformer.visit(ForStmt(stmt01, BoolValue(true), stmt02))
     assert(stmt01.accept(visitor).size == 1)
     assert(stmt02.accept(visitor).size == 0)
     assert(stmt03.accept(visitor).size == 1)
@@ -320,7 +320,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     visitor.env.setGlobalVariable("x", IntegerType)
     visitor.env.setGlobalVariable("y", IntegerType)
 
-    val stmt03 = ForStmt(stmt01,IntValue(10), stmt02).accept(coreTransformer)
+    val stmt03 = coreTransformer.visit(ForStmt(stmt01,IntValue(10), stmt02))
     assert(stmt01.accept(visitor).size == 0)
     assert(stmt02.accept(visitor).size == 0)
     assert(stmt03.accept(visitor).size == 1)
@@ -334,7 +334,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
 
     visitor.env.setGlobalVariable("x", IntegerType)
 
-    val stmt03 = ForStmt(stmt01, BoolValue(true), stmt02).accept(coreTransformer)
+    val stmt03 = coreTransformer.visit(ForStmt(stmt01, BoolValue(true), stmt02))
     assert(stmt01.accept(visitor).size == 0)
     assert(stmt02.accept(visitor).size == 1)
     assert(stmt03.accept(visitor).size == 1)
@@ -349,7 +349,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     visitor.env.setGlobalVariable("x", IntegerType)
     visitor.env.setGlobalVariable("y", IntegerType)
 
-    val stmt03 = ForStmt(stmt01, BoolValue(true), stmt02).accept(coreTransformer)
+    val stmt03 = coreTransformer.visit(ForStmt(stmt01, BoolValue(true), stmt02))
     assert(stmt01.accept(visitor).size == 0)
     assert(stmt02.accept(visitor).size == 0)
     assert(stmt03.accept(visitor).size == 0)
@@ -728,7 +728,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
 
     val condition  = LTExpression(VarExpression("x"), IntValue(10))
     val stmt01     = ReadIntStmt("x")
-    val repeatStmt = RepeatUntilStmt(condition, stmt01).accept(coreTransformer)
+    val repeatStmt = coreTransformer.visit(RepeatUntilStmt(condition, stmt01))
 
     visitor.env.setGlobalVariable("x", IntegerType)
 
@@ -743,7 +743,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
 
     val condition  = EQExpression(VarExpression("x"), IntValue(0))
     val stmt01     = ReadIntStmt("x")
-    val repeatStmt = RepeatUntilStmt(condition, stmt01).accept(coreTransformer)
+    val repeatStmt = coreTransformer.visit(RepeatUntilStmt(condition, stmt01))
 
     visitor.env.setGlobalVariable("x", IntegerType)
 
@@ -757,7 +757,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val visitor = new TypeChecker()
     val stmt01  =  AssignmentStmt("x", IntValue(10))
 
-    val stmt02  = RepeatUntilStmt(BoolValue(true), stmt01).accept(coreTransformer)
+    val stmt02  = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), stmt01))
 
     assert(stmt01.accept(visitor).size == 1)
     assert(stmt02.accept(visitor).size == 1)
@@ -772,7 +772,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val stmt03 = IfElseStmt(BoolValue(false), stmt01, Some(stmt02))
     val stmt04 = AssignmentStmt("x", IntValue(20))
     val stmt05 = SequenceStmt(List(stmt01, stmt02, stmt03, stmt04))
-    val stmt06 = RepeatUntilStmt(BoolValue(true), stmt05).accept(coreTransformer)
+    val stmt06 = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), stmt05))
 
     assert(stmt01.accept(visitor).size == 1)
     assert(stmt02.accept(visitor).size == 1)
@@ -790,7 +790,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
   val condition  = AndExpression(GTEExpression(VarExpression("x"), IntValue(1)),
     LTEExpression(VarExpression("x"), IntValue(10)))
   val stmt01     = ReadIntStmt("x")
-  val repeatStmt = RepeatUntilStmt(condition, stmt01).accept(coreTransformer)
+  val repeatStmt = coreTransformer.visit(RepeatUntilStmt(condition, stmt01))
 
   visitor.env.setGlobalVariable("x", IntegerType)
 
@@ -804,10 +804,10 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val visitor = new TypeChecker()
 
     val stmt01 = AssignmentStmt("x", IntValue(10))
-    val repeatStmt01 = RepeatUntilStmt(BoolValue(true), stmt01).accept(coreTransformer)
-    val repeatStmt02 = RepeatUntilStmt(BoolValue(true), repeatStmt01).accept(coreTransformer)
-    val repeatStmt03 = RepeatUntilStmt(BoolValue(true), repeatStmt02).accept(coreTransformer)
-    val repeatStmt04 = RepeatUntilStmt(BoolValue(true), repeatStmt03).accept(coreTransformer)
+    val repeatStmt01 = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), stmt01))
+    val repeatStmt02 = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), repeatStmt01))
+    val repeatStmt03 = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), repeatStmt02))
+    val repeatStmt04 = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), repeatStmt03))
 
     visitor.env.setGlobalVariable("x", IntegerType)
     val allStmts = List(stmt01, repeatStmt01, repeatStmt02, repeatStmt03, repeatStmt04)
@@ -822,10 +822,10 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val visitor = new TypeChecker()
 
     val stmt01       = AssignmentStmt("x", IntValue(10))
-    val repeatStmt01 = RepeatUntilStmt(BoolValue(true), stmt01).accept(coreTransformer)
-    val repeatStmt02 = RepeatUntilStmt(BoolValue(true), repeatStmt01).accept(coreTransformer)
-    val repeatStmt03 = RepeatUntilStmt(BoolValue(true), repeatStmt02).accept(coreTransformer)
-    val repeatStmt04 = RepeatUntilStmt(BoolValue(true), repeatStmt03).accept(coreTransformer)
+    val repeatStmt01 = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), stmt01))
+    val repeatStmt02 = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), repeatStmt01))
+    val repeatStmt03 = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), repeatStmt02))
+    val repeatStmt04 = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), repeatStmt03))
 
     val allStmts = List(repeatStmt01, repeatStmt02, repeatStmt03, repeatStmt04)
 
@@ -840,7 +840,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
 
     val boolVar    = VarExpression("flag")
     val stmt01     = AssignmentStmt(boolVar.name, BoolValue(true))
-    val repeatStmt = RepeatUntilStmt(boolVar, stmt01).accept(coreTransformer)
+    val repeatStmt = coreTransformer.visit(RepeatUntilStmt(boolVar, stmt01))
 
     visitor.env.setGlobalVariable("flag", BooleanType)
 
@@ -853,7 +853,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val visitor = new TypeChecker()
 
     val stmt01     = AssignmentStmt("x", BoolValue(false))
-    val repeatStmt = RepeatUntilStmt(BoolValue(true), stmt01).accept(coreTransformer)
+    val repeatStmt = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), stmt01))
     val stmt02     = SequenceStmt(List(stmt01, repeatStmt, stmt01, repeatStmt))
 
     visitor.env.setGlobalVariable("x", IntegerType)
@@ -866,7 +866,7 @@ class TypeCheckerTestSuite  extends AbstractTestSuite {
     val visitor = new TypeChecker()
 
     val stmt01     = AssignmentStmt("x", BoolValue(false))
-    val repeatStmt = RepeatUntilStmt(BoolValue(true), stmt01).accept(coreTransformer)
+    val repeatStmt = coreTransformer.visit(RepeatUntilStmt(BoolValue(true), stmt01))
     val stmt02     = SequenceStmt(List(stmt01, repeatStmt, stmt01, repeatStmt))
 
     assert(stmt02.accept(visitor).size == 4)


### PR DESCRIPTION
# Refatoração do Core Transformer
O objetivo é tornar o código mais funcional e evitar uso de variáveis e variáveis globais. Após as modificações não acrescentamos novos testes mas os atuais estão funcionando corretamente. 

## CoreVisitor

- [x] Remoção da função transformListStmts
- [x] TransformProcedureStatement aceita uma procedure como argumento e retorna uma procedure com os stmt do tipo core
- [x] Contador: utilizamos o AtomicInteger ([link de referência](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/AtomicInteger.html))
- [x] Novas variáveis - estamos utilizando um array buffer para incrementar a lista de variáveis ([link de referência](https://www.baeldung.com/scala/arraybuffer))

## CoreChecker
- [x] Alterando código para linguagem funcional
- [x] Eliminação do uso de visitors
- [x] Exclusão da função checkProcedureStmts que não estava sendo utilizada em nenhuma parte do programa
- [x] Exclusão da função transformListStmts

## Grupo 1
Cássio Vinícius - 211036141
Felipe Costa - 211055236 
Jean Bueno - 211055290 
Pedro Farias - 211055577 
Vitor Lemos - 202037720 