### PR TITLE
Enabling Module Loader Tests

### DIFF
--- a/src/main/scala/br/unb/cic/oberon/parser/ModuleLoader.scala
+++ b/src/main/scala/br/unb/cic/oberon/parser/ModuleLoader.scala
@@ -97,6 +97,7 @@ sealed class ModuleMerger(val loader: ModuleLoader) {
       constants,
       variables,
       procedures,
+      // None
       Some(stmt)
     )
   }

--- a/src/test/scala/br/unb/cic/oberon/parser/ModuleLoaderTest.scala
+++ b/src/test/scala/br/unb/cic/oberon/parser/ModuleLoaderTest.scala
@@ -28,27 +28,27 @@ class ModuleLoaderTestSuite extends AbstractTestSuite {
     )
   }
 
-  ignore("Testing if the ModuleLoader imports a file") {
+  test("Testing if the ModuleLoader imports a file") {
     val module = ResourceModuleLoader.loadAndMerge("imports/A.oberon")
 
     val expected = makeModule(
       name = "A",
-      variables = List(VariableDeclaration("A::x", IntegerType)),
-      stmt = Some(SequenceStmt(List(AssignmentStmt("A::x", IntValue(1)))))
+      variables = List(VariableDeclaration("x", IntegerType)),
+      stmt = Some(SequenceStmt(List(AssignmentStmt("x", IntValue(1)))))
     )
     assert(module == expected)
   }
 
-  ignore("Testing if the ModuleLoader loads an import recursively") {
+  test("Testing if the ModuleLoader loads an import recursively") {
     val module = ResourceModuleLoader.loadAndMerge("imports/B.oberon")
 
     val expected = makeModule(
       name = "B",
-      variables = List(VariableDeclaration("A::x", IntegerType)),
+      variables = List(VariableDeclaration("x", IntegerType)),
       stmt = Some(
         SequenceStmt(
           List(
-            AssignmentStmt("A::x", IntValue(1)),
+            AssignmentStmt("x", IntValue(1)),
             WriteStmt(VarExpression("A::x"))
           )
         )


### PR DESCRIPTION
## Problemas
Atualmente a função de merge deve ser refatorada, considerando que para o exemplo:
* `A.oberon`:
```
MODULE A;

VAR
    x : INTEGER;

BEGIN
    x := 1
END

END A.
```
* `B.oberon`:
```
MODULE B;

IMPORT A;

BEGIN
    write(A::x)
END

END B.
```

O resultado atual é:
```
MODULE B;

VAR
    x : INTEGER;

BEGIN
    x := 1
    write(A::x)
END

END B.
```